### PR TITLE
RMB-30 move raml-util

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "raml-util"]
-	path = raml-util
+	path = ramls/raml-util
 	url = https://github.com/folio-org/raml.git

--- a/mod-configuration-client/pom.xml
+++ b/mod-configuration-client/pom.xml
@@ -11,7 +11,6 @@
   </parent>
 
   <properties>
-    <ramlfiles_path>${basedir}/../ramls</ramlfiles_path>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 

--- a/mod-configuration-server/pom.xml
+++ b/mod-configuration-server/pom.xml
@@ -9,8 +9,6 @@
   <artifactId>mod-configuration-server</artifactId>
 
   <properties>
-    <ramlfiles_path>${basedir}/../ramls</ramlfiles_path>
-    <ramlfiles_util_path>${basedir}/../raml-util</ramlfiles_util_path>
     <tablespace_dir>c:\\git\\postgres</tablespace_dir>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
@@ -188,22 +186,6 @@
               <resources>
                 <resource>
                   <directory>${ramlfiles_path}</directory>
-                  <filtering>true</filtering>
-                </resource>
-              </resources>
-            </configuration>
-          </execution>
-          <execution>
-            <id>copy-resources-2</id>
-            <phase>prepare-package</phase>
-            <goals>
-              <goal>copy-resources</goal>
-            </goals>
-            <configuration>
-              <outputDirectory>${basedir}/target/classes/apidocs/raml-util</outputDirectory>
-              <resources>
-                <resource>
-                  <directory>${ramlfiles_util_path}</directory>
                   <filtering>true</filtering>
                 </resource>
               </resources>

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
     <filebeat_log_path>${basedir}/logs/filebeat</filebeat_log_path>
     <filebeat_registry_file>${basedir}/logs/filebeat/registry</filebeat_registry_file>
     <logstash_instance>ec2-52-41-57-165.us-west-2.compute.amazonaws.com:5044</logstash_instance>
+    <ramlfiles_path>${project.parent.basedir}/ramls</ramlfiles_path>
   </properties>
 
   <repositories>

--- a/ramls/_schemas/README.md
+++ b/ramls/_schemas/README.md
@@ -1,1 +1,1 @@
-As a workaround to FOLIO-573, when any schema file refers to an additional schema file, then use the filename of that referenced second schema as the "key" name in the RAML "schemas" section, and wherever that schema is utilised in RAML and schema files.
+When any schema file refers to an additional schema file, then also use that pathname of the referenced second schema as the "key" name in the RAML "schemas" section, and wherever that schema is utilised in RAML files. Also ensure that all such referenced files are below the parent file.

--- a/ramls/configuration/config.raml
+++ b/ramls/configuration/config.raml
@@ -15,22 +15,22 @@ schemas:
   - libraries: !include ../_schemas/library.schema
   - audits: !include ../_schemas/audits.schema
   - audit.schema: !include ../_schemas/audit.schema
-  - errors: !include ../../raml-util/schemas/errors.schema
-  - error.schema: !include ../../raml-util/schemas/error.schema
-  - parameters.schema: !include ../../raml-util/schemas/parameters.schema
+  - errors: !include ../raml-util/schemas/errors.schema
+  - error.schema: !include ../raml-util/schemas/error.schema
+  - parameters.schema: !include ../raml-util/schemas/parameters.schema
 
 traits:
-  - secured: !include ../../raml-util/traits/auth.raml
-  - orderable: !include ../../raml-util/traits/orderable.raml
-  - pageable:  !include ../../raml-util/traits/pageable.raml
-  - searchable: !include ../../raml-util/traits/searchable.raml
-  - language: !include ../../raml-util/traits/language.raml
-  - validate: !include ../../raml-util/traits/validation.raml
+  - secured: !include ../raml-util/traits/auth.raml
+  - orderable: !include ../raml-util/traits/orderable.raml
+  - pageable:  !include ../raml-util/traits/pageable.raml
+  - searchable: !include ../raml-util/traits/searchable.raml
+  - language: !include ../raml-util/traits/language.raml
+  - validate: !include ../raml-util/traits/validation.raml
 
 resourceTypes:
-  - collection: !include ../../raml-util/rtypes/collection.raml
-  - collection-item: !include ../../raml-util/rtypes/item-collection.raml
-  - get-only: !include ../../raml-util/rtypes/get-only.raml
+  - collection: !include ../raml-util/rtypes/collection.raml
+  - collection-item: !include ../raml-util/rtypes/item-collection.raml
+  - get-only: !include ../raml-util/rtypes/get-only.raml
 
 /configurations:
   /entries:


### PR DESCRIPTION
Move raml-util to inside ramls directory.
Enables reliable use of pathname for $ref in schema files.