### PR TITLE
FOLIO-972 Improve UUID-like regex

### DIFF
--- a/ramls/_schemas/kv_configuration.schema
+++ b/ramls/_schemas/kv_configuration.schema
@@ -4,7 +4,7 @@
   "properties": {
     "id": {
       "type": "string",
-      "pattern": "^[a-f0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
     },
     "module": {
       "type": "string"


### PR DESCRIPTION
Enable upper-case in first segment.

This came in with the recent pull/#38 for MODCONF-17, while other patterns were fixed some time ago with FOLIO-972.

Perhaps there is a copy-and-paste somewhere.