### PR TITLE
Split existing api tests MODCONF-23

### DIFF
--- a/mod-configuration-server/src/test/java/org/folio/rest/RestVerticleTest.java
+++ b/mod-configuration-server/src/test/java/org/folio/rest/RestVerticleTest.java
@@ -131,9 +131,16 @@ public class RestVerticleTest {
   @Test
   public void checkURLs(TestContext context) {
     createSampleRecords(context);
+    changeLogLevel(context);
     waitForTwoSeconds();
     checkPersistentCaching(context);
     checkResultsFromVariousUrls(context);
+  }
+
+  private void changeLogLevel(TestContext context) {
+    mutateURLs("http://localhost:" + port +
+        "/admin/loglevel?level=FINE&java_package=org.folio.rest.persist",
+      context, HttpMethod.PUT,"",  "application/json", 200);
   }
 
   private void checkResultsFromVariousUrls(TestContext context) {
@@ -232,9 +239,6 @@ public class RestVerticleTest {
       System.out.println(updatedConf);
       mutateURLs("http://localhost:" + port + "/configurations/entries", context, HttpMethod.POST,
         updatedConf, "application/json", 201);
-
-      mutateURLs("http://localhost:" + port + "/admin/loglevel?level=FINE&java_package=org.folio.rest.persist", context,
-        HttpMethod.PUT,"",  "application/json", 200);
 
     } catch (Exception e) {
       e.printStackTrace();

--- a/mod-configuration-server/src/test/java/org/folio/rest/RestVerticleTest.java
+++ b/mod-configuration-server/src/test/java/org/folio/rest/RestVerticleTest.java
@@ -118,22 +118,22 @@ public class RestVerticleTest {
     PostgresClient.getInstance(vertx).startEmbeddedPostgres();
   }
 
+  @Test
+  public void canChangeLogLevel(TestContext context) {
+    mutateURLs("http://localhost:" + port +
+        "/admin/loglevel?level=FINE&java_package=org.folio.rest.persist",
+      context, HttpMethod.PUT,"",  "application/json", 200);
+  }
+
   /**
    * This method, iterates through the urls.csv and runs each url - currently only checking the returned status codes
    */
   @Test
   public void checkURLs(TestContext context) {
     createSampleRecords(context);
-    changeLogLevel(context);
     waitForTwoSeconds();
     checkPersistentCaching(context);
     checkResultsFromVariousUrls(context);
-  }
-
-  private void changeLogLevel(TestContext context) {
-    mutateURLs("http://localhost:" + port +
-        "/admin/loglevel?level=FINE&java_package=org.folio.rest.persist",
-      context, HttpMethod.PUT,"",  "application/json", 200);
   }
 
   private void checkResultsFromVariousUrls(TestContext context) {

--- a/mod-configuration-server/src/test/java/org/folio/rest/RestVerticleTest.java
+++ b/mod-configuration-server/src/test/java/org/folio/rest/RestVerticleTest.java
@@ -41,6 +41,8 @@ import java.util.concurrent.TimeoutException;
 public class RestVerticleTest {
   private static final String SECRET_KEY = "b2+S+X4F/NFys/0jMaEG1A";
   private static final String TENANT_ID = "harvard";
+  private static final String USER_ID = "79ff2a8b-d9c3-5b39-ad4a-0a84025ab085";
+  private static final String TOKEN = "eyJhbGciOiJIUzUxMiJ9eyJzdWIiOiJhZG1pbiIsInVzZXJfaWQiOiI3OWZmMmE4Yi1kOWMzLTViMzktYWQ0YS0wYTg0MDI1YWIwODUiLCJ0ZW5hbnQiOiJ0ZXN0X3RlbmFudCJ9BShwfHcNClt5ZXJ8ImQTMQtAM1sQEnhsfWNmXGsYVDpuaDN3RVQ9";
 
   private static Locale oldLocale;
   private static Vertx vertx;
@@ -70,7 +72,7 @@ public class RestVerticleTest {
 
     port = NetworkUtils.nextFreePort();
 
-    tClient = new TenantClient("localhost", port, TENANT_ID, TENANT_ID);
+    tClient = new TenantClient("localhost", port, TENANT_ID, TOKEN);
 
     DeploymentOptions options = new DeploymentOptions().setConfig(
       new JsonObject().put("http.port", port));
@@ -146,7 +148,7 @@ public class RestVerticleTest {
             postgresClient.removePersistentCacheResult("mytablecache", r4 -> {
               System.out.println(r4.succeeded());
 
-              /** this will probably cause a deadlock as the saveBatch runs within a transaction */
+              /* this will probably cause a deadlock as the saveBatch runs within a transaction */
 
              /*
              List<Object> a = Arrays.asList(new Object[]{new JsonObject("{\"module1\": \"CIRCULATION\"}"),
@@ -288,8 +290,10 @@ public class RestVerticleTest {
             });
           });
         request.putHeader("X-Okapi-Request-Id", "999999999999");
-        request.putHeader("x-okapi-tenant", TENANT_ID);
         request.headers().add("Authorization", TENANT_ID);
+        request.putHeader("x-Okapi-Tenant", TENANT_ID);
+        request.putHeader("x-Okapi-Token", TOKEN);
+        request.putHeader("x-Okapi-User-Id", USER_ID);
         request.headers().add("Accept", "application/json");
         request.setChunked(true);
         request.end();
@@ -362,7 +366,9 @@ public class RestVerticleTest {
     request.setChunked(true);
     request.putHeader("X-Okapi-Request-Id", "999999999999");
     request.putHeader("Authorization", TENANT_ID);
-    request.putHeader("x-okapi-tenant", TENANT_ID);
+    request.putHeader("x-Okapi-Tenant", TENANT_ID);
+    request.putHeader("x-Okapi-Token", TOKEN);
+    request.putHeader("x-Okapi-User-Id", USER_ID);
     request.putHeader("Accept", "application/json,text/plain");
     request.putHeader("Content-type", contentType);
     request.end(buffer);

--- a/mod-configuration-server/src/test/java/org/folio/rest/RestVerticleTest.java
+++ b/mod-configuration-server/src/test/java/org/folio/rest/RestVerticleTest.java
@@ -1,34 +1,8 @@
 package org.folio.rest;
 
 
-import java.io.BufferedReader;
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.util.ArrayList;
-import java.util.Base64;
-import java.util.Date;
-import java.util.Locale;
-
-import org.apache.commons.io.IOUtils;
-import org.folio.rest.client.TenantClient;
-import org.folio.rest.jaxrs.model.Config;
-import org.folio.rest.jaxrs.model.Metadata;
-import org.folio.rest.jaxrs.model.TenantAttributes;
-import org.folio.rest.persist.PostgresClient;
-import org.folio.rest.security.AES;
-import org.folio.rest.tools.utils.NetworkUtils;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.io.ByteStreams;
-
 import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
@@ -42,6 +16,23 @@ import io.vertx.core.logging.LoggerFactory;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.apache.commons.io.IOUtils;
+import org.folio.rest.client.TenantClient;
+import org.folio.rest.jaxrs.model.Config;
+import org.folio.rest.jaxrs.model.Metadata;
+import org.folio.rest.jaxrs.model.TenantAttributes;
+import org.folio.rest.persist.PostgresClient;
+import org.folio.rest.security.AES;
+import org.folio.rest.tools.utils.NetworkUtils;
+import org.junit.*;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.*;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Date;
+import java.util.Locale;
 
 /**
  * This is our JUnit test for our verticle. The test uses vertx-unit, so we declare a custom runner.
@@ -70,11 +61,6 @@ public class RestVerticleTest {
     Locale.setDefault(oldLocale);
   }
 
-  /**
-   *
-   * @param context
-   *          the test context.
-   */
   @Before
   public void setUp(TestContext context) throws IOException {
     vertx = Vertx.vertx();
@@ -141,12 +127,6 @@ public class RestVerticleTest {
     PostgresClient.getInstance(vertx).startEmbeddedPostgres();
   }
 
-  /**
-   * This method, called after our test, just cleanup everything by closing the vert.x instance
-   *
-   * @param context
-   *          the test context
-   */
   @After
   public void tearDown(TestContext context) {
     Async async = context.async();
@@ -159,19 +139,15 @@ public class RestVerticleTest {
         }));
       });
     });
-
   }
 
   /**
    * This method, iterates through the urls.csv and runs each url - currently only checking the returned status codes
-   *
-   * @param context the test context
    */
   @Test
   public void checkURLs(TestContext context) {
 
     try {
-
       //save config entry
       String content = getFile("kv_configuration.sample");
       Config conf =  new ObjectMapper().readValue(content, Config.class);
@@ -289,7 +265,6 @@ public class RestVerticleTest {
 
   }
 
-
   private void runGETURLoop(TestContext context){
     try {
       int[] urlCount = { urls.size() };
@@ -361,14 +336,6 @@ public class RestVerticleTest {
     }
   }
 
-  /**
-   * for POST / PUT / DELETE
-   * @param api
-   * @param context
-   * @param method
-   * @param content
-   * @param id
-   */
   private void mutateURLs(String api, TestContext context, HttpMethod method, String content,
       String contentType, int errorCode) {
     Async async = context.async();
@@ -461,5 +428,4 @@ public class RestVerticleTest {
   private String getFile(String filename) throws IOException {
     return IOUtils.toString(getClass().getClassLoader().getResourceAsStream(filename), "UTF-8");
   }
-
 }

--- a/mod-configuration-server/src/test/java/org/folio/rest/RestVerticleTest.java
+++ b/mod-configuration-server/src/test/java/org/folio/rest/RestVerticleTest.java
@@ -37,8 +37,8 @@ import java.util.*;
 public class RestVerticleTest {
   private static Locale oldLocale;
   private static Vertx vertx;
-  private int port;
-  private TenantClient tClient = null;
+  private static int port;
+  private static TenantClient tClient = null;
 
   static {
     System.setProperty(LoggerFactory.LOGGER_DELEGATE_FACTORY_CLASS_NAME,
@@ -46,18 +46,10 @@ public class RestVerticleTest {
   }
 
   @BeforeClass
-  public static void setUpClass() {
+  public static void beforeAll(TestContext context) {
     oldLocale = Locale.getDefault();
     Locale.setDefault(Locale.US);
-  }
 
-  @AfterClass
-  public static void tearDownClass() {
-    Locale.setDefault(oldLocale);
-  }
-
-  @Before
-  public void setUp(TestContext context) {
     vertx = Vertx.vertx();
 
     try {
@@ -102,17 +94,10 @@ public class RestVerticleTest {
         e.printStackTrace();
       }
     }));
-
   }
 
-  private static void setupPostgres() throws IOException {
-    PostgresClient.setIsEmbedded(true);
-    PostgresClient.setEmbeddedPort(NetworkUtils.nextFreePort());
-    PostgresClient.getInstance(vertx).startEmbeddedPostgres();
-  }
-
-  @After
-  public void tearDown(TestContext context) {
+  @AfterClass
+  public static void afterAll(TestContext context) {
     Async async = context.async();
     tClient.delete( reply -> {
       reply.bodyHandler( body2 -> {
@@ -123,6 +108,14 @@ public class RestVerticleTest {
         }));
       });
     });
+
+    Locale.setDefault(oldLocale);
+  }
+
+  private static void setupPostgres() throws IOException {
+    PostgresClient.setIsEmbedded(true);
+    PostgresClient.setEmbeddedPort(NetworkUtils.nextFreePort());
+    PostgresClient.getInstance(vertx).startEmbeddedPostgres();
   }
 
   /**

--- a/mod-configuration-server/src/test/java/org/folio/rest/RestVerticleTest.java
+++ b/mod-configuration-server/src/test/java/org/folio/rest/RestVerticleTest.java
@@ -399,36 +399,26 @@ public class RestVerticleTest {
   }
 
   private CompletableFuture<Void> deleteAllConfigurationRecordsExceptLocales() {
-    CompletableFuture<Void> allDeleted = new CompletableFuture<>();
-
-    final PostgresClient postgresClient = PostgresClient.getInstance(vertx, TENANT_ID);
-
-    //Do not delete the sample records created from
-    postgresClient.mutate(String.format("DELETE FROM %s_%s.config_data WHERE jsonb->>'configName' != 'locale'",
-      TENANT_ID, "mod_configuration"), reply -> {
-      if(reply.succeeded()) {
-        allDeleted.complete(null);
-      }
-      else {
-        allDeleted.completeExceptionally(reply.cause());
-      }
-    });
-
-    return allDeleted;
+    return deleteAllConfigurationRecordsFromTableExceptLocales("config_data");
   }
 
   private CompletableFuture<Void> deleteAllConfigurationAuditRecordsExceptLocales() {
+    return deleteAllConfigurationRecordsFromTableExceptLocales("audit_config_data");
+  }
+
+  private CompletableFuture<Void> deleteAllConfigurationRecordsFromTableExceptLocales(
+    String audit_config_data) {
+
     CompletableFuture<Void> allDeleted = new CompletableFuture<>();
 
     final PostgresClient postgresClient = PostgresClient.getInstance(vertx, TENANT_ID);
 
     //Do not delete the sample records created from
-    postgresClient.mutate(String.format("DELETE FROM %s_%s.audit_config_data WHERE jsonb->>'configName' != 'locale'",
-      TENANT_ID, "mod_configuration"), reply -> {
-      if(reply.succeeded()) {
+    postgresClient.mutate(String.format("DELETE FROM %s_%s.%s WHERE jsonb->>'configName' != 'locale'",
+      TENANT_ID, "mod_configuration", audit_config_data), reply -> {
+      if (reply.succeeded()) {
         allDeleted.complete(null);
-      }
-      else {
+      } else {
         allDeleted.completeExceptionally(reply.cause());
       }
     });

--- a/mod-configuration-server/src/test/java/org/folio/rest/RestVerticleTest.java
+++ b/mod-configuration-server/src/test/java/org/folio/rest/RestVerticleTest.java
@@ -73,24 +73,13 @@ public class RestVerticleTest {
 
     tClient = new TenantClient("localhost", port, "harvard", "harvard");
 
-/*    port = 8888;//NetworkUtils.nextFreePort();
+    DeploymentOptions options = new DeploymentOptions().setConfig(
+      new JsonObject().put("http.port", port));
 
-    AdminClient aClient = new AdminClient("localhost", port, "myuniversity");
-    try {
-      aClient.postImportSQL(
-        RestVerticleTest.class.getClassLoader().getResourceAsStream("create_config.sql"), reply -> {
-          async.complete();
-        });
-    } catch (Exception e) {
-      e.printStackTrace();
-    }*/
-    DeploymentOptions options = new DeploymentOptions().setConfig(new JsonObject().put("http.port",
-      port));
     vertx.deployVerticle(RestVerticle.class.getName(), options, context.asyncAssertSuccess(id -> {
       try {
         TenantAttributes ta = new TenantAttributes();
         ta.setModuleFrom("v1");
-        //ta.setModuleTo("v2");
         tClient.post(ta, response -> {
           if(422 == response.statusCode()){
             try {
@@ -247,19 +236,6 @@ public class RestVerticleTest {
       mutateURLs("http://localhost:" + port + "/admin/loglevel?level=FINE&java_package=org.folio.rest.persist", context,
         HttpMethod.PUT,"",  "application/json", 200);
 
-/*      conf2.setMetadata(null);
-      conf2.setModule("BATCH");
-      conf2.setValue("what1");
-      Config conf3 = (Config)BeanUtils.cloneBean(conf2);
-      conf3.setValue("what2");
-      Configs c = new Configs();
-      List<Config> configArray = new ArrayList<>();
-      configArray.add(conf2);
-      configArray.add(conf3);
-      c.setConfigs(configArray);
-      mutateURLs("http://localhost:" + port + "/configurations/entries", context, HttpMethod.PUT,
-        new ObjectMapper().writeValueAsString(c), "application/json", 204);*/
-
     } catch (Exception e) {
       e.printStackTrace();
       context.assertTrue(false, e.getMessage());
@@ -303,17 +279,6 @@ public class RestVerticleTest {
                         async.complete();
                       }
                     }
-/*                    aClient.getModuleStats( res -> {
-                      res.bodyHandler( b -> {
-                        System.out.println(urlInfo[1] + "  "+b.toString());
-                        aClient.getHealth( r -> {
-                          r.bodyHandler( bh -> {
-                            System.out.println(urlInfo[1] + "  "+bh.toString());
-                            async.complete();
-                          });
-                        });
-                      });
-                    });*/
                   }
                   catch(Exception e){
                     e.printStackTrace();
@@ -372,7 +337,6 @@ public class RestVerticleTest {
       if(method == HttpMethod.POST && statusCode == 201){
         try {
           System.out.println("Location - " + response.getHeader("Location"));
-          //String content2 = getFile("kv_configuration.sample");
           Config conf =  new ObjectMapper().readValue(content, Config.class);
           conf.setDescription(conf.getDescription());
           mutateURLs("http://localhost:" + port + response.getHeader("Location"), context, HttpMethod.PUT,
@@ -386,7 +350,7 @@ public class RestVerticleTest {
         context.assertTrue(true);
       }
       else if(expectedStatusCode == 0){
-        //currently dont care about return value
+        //currently don't care about return value
         context.assertTrue(true);
       }
       else {

--- a/mod-configuration-server/src/test/java/org/folio/rest/RestVerticleTest.java
+++ b/mod-configuration-server/src/test/java/org/folio/rest/RestVerticleTest.java
@@ -49,16 +49,16 @@ import io.vertx.ext.unit.junit.VertxUnitRunner;
  */
 @RunWith(VertxUnitRunner.class)
 public class RestVerticleTest {
-
-  private static Locale     oldLocale;
-  private static Vertx      vertx;
+  private static Locale oldLocale;
+  private static Vertx vertx;
   private ArrayList<String> urls;
-  int                       port;
-  TenantClient tClient = null;
-  AdminClient aClient  = null;
+  private int port;
+  private TenantClient tClient = null;
+  private AdminClient aClient  = null;
 
   static {
-    System.setProperty(LoggerFactory.LOGGER_DELEGATE_FACTORY_CLASS_NAME, "io.vertx.core.logging.Log4jLogDelegateFactory");
+    System.setProperty(LoggerFactory.LOGGER_DELEGATE_FACTORY_CLASS_NAME,
+      "io.vertx.core.logging.Log4jLogDelegateFactory");
   }
 
   @BeforeClass

--- a/mod-configuration-server/src/test/java/org/folio/rest/RestVerticleTest.java
+++ b/mod-configuration-server/src/test/java/org/folio/rest/RestVerticleTest.java
@@ -12,7 +12,6 @@ import java.util.Date;
 import java.util.Locale;
 
 import org.apache.commons.io.IOUtils;
-import org.folio.rest.client.AdminClient;
 import org.folio.rest.client.TenantClient;
 import org.folio.rest.jaxrs.model.Config;
 import org.folio.rest.jaxrs.model.Metadata;
@@ -54,7 +53,6 @@ public class RestVerticleTest {
   private ArrayList<String> urls;
   private int port;
   private TenantClient tClient = null;
-  private AdminClient aClient  = null;
 
   static {
     System.setProperty(LoggerFactory.LOGGER_DELEGATE_FACTORY_CLASS_NAME,
@@ -92,7 +90,6 @@ public class RestVerticleTest {
 
     port = NetworkUtils.nextFreePort();
 
-    aClient = new AdminClient("localhost", port, "harvard", "harvard");
     tClient = new TenantClient("localhost", port, "harvard", "harvard");
 
 /*    port = 8888;//NetworkUtils.nextFreePort();

--- a/mod-configuration-server/src/test/java/org/folio/rest/RestVerticleTest.java
+++ b/mod-configuration-server/src/test/java/org/folio/rest/RestVerticleTest.java
@@ -125,22 +125,8 @@ public class RestVerticleTest {
       context, HttpMethod.PUT,"",  "application/json", 200);
   }
 
-  /**
-   * This method, iterates through the urls.csv and runs each url - currently only checking the returned status codes
-   */
   @Test
-  public void checkURLs(TestContext context) {
-    createSampleRecords(context);
-    waitForTwoSeconds();
-    checkPersistentCaching(context);
-    checkResultsFromVariousUrls(context);
-  }
-
-  private void checkResultsFromVariousUrls(TestContext context) {
-    runGETURLoop(context, urlsFromFile());
-  }
-
-  private void checkPersistentCaching(TestContext context) {
+  public void canUsePersistentCaching(TestContext context) {
     Async async = context.async();
 
     final PostgresClient postgresClient = PostgresClient.getInstance(vertx, "harvard");
@@ -174,6 +160,20 @@ public class RestVerticleTest {
           });
         }
       });
+  }
+
+  /**
+   * This method, iterates through the urls.csv and runs each url - currently only checking the returned status codes
+   */
+  @Test
+  public void checkURLs(TestContext context) {
+    createSampleRecords(context);
+    waitForTwoSeconds();
+    checkResultsFromVariousUrls(context);
+  }
+
+  private void checkResultsFromVariousUrls(TestContext context) {
+    runGETURLoop(context, urlsFromFile());
   }
 
   private void waitForTwoSeconds() {

--- a/mod-configuration-server/src/test/java/org/folio/rest/RestVerticleTest.java
+++ b/mod-configuration-server/src/test/java/org/folio/rest/RestVerticleTest.java
@@ -2,7 +2,6 @@ package org.folio.rest;
 
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.io.ByteStreams;
 import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
@@ -28,11 +27,8 @@ import org.junit.*;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import java.io.*;
-import java.util.ArrayList;
-import java.util.Base64;
-import java.util.Date;
-import java.util.Locale;
+import java.io.IOException;
+import java.util.*;
 
 /**
  * This is our JUnit test for our verticle. The test uses vertx-unit, so we declare a custom runner.
@@ -400,28 +396,15 @@ public class RestVerticleTest {
     request.end(buffer);
   }
 
-  private ArrayList<String> urlsFromFile() throws IOException {
+  private ArrayList<String> urlsFromFile() {
     ArrayList<String> ret = new ArrayList<>();
-    byte[] content = ByteStreams.toByteArray(getClass().getResourceAsStream("/urls.csv"));
-    InputStream is = null;
-    BufferedReader bfReader = null;
-    try {
-      is = new ByteArrayInputStream(content);
-      bfReader = new BufferedReader(new InputStreamReader(is));
-      String temp = null;
-      while ((temp = bfReader.readLine()) != null) {
-        ret.add(temp);
-      }
-    } catch (IOException e) {
-      e.printStackTrace();
-    } finally {
-      try {
-        if (is != null)
-          is.close();
-      } catch (Exception ex) {
 
+    try (Scanner scanner = new Scanner(getClass().getResourceAsStream("/urls.csv"))) {
+    while(scanner.hasNext()) {
+        ret.add(scanner.nextLine());
       }
     }
+
     return ret;
   }
 

--- a/mod-configuration-server/src/test/java/org/folio/rest/RestVerticleTest.java
+++ b/mod-configuration-server/src/test/java/org/folio/rest/RestVerticleTest.java
@@ -58,7 +58,7 @@ public class RestVerticleTest {
   }
 
   @Before
-  public void setUp(TestContext context) throws IOException {
+  public void setUp(TestContext context) {
     vertx = Vertx.vertx();
 
     try {
@@ -117,7 +117,7 @@ public class RestVerticleTest {
 
   }
 
-  private static void setupPostgres() throws Exception {
+  private static void setupPostgres() throws IOException {
     PostgresClient.setIsEmbedded(true);
     PostgresClient.setEmbeddedPort(NetworkUtils.nextFreePort());
     PostgresClient.getInstance(vertx).startEmbeddedPostgres();

--- a/mod-configuration-server/src/test/java/org/folio/rest/RestVerticleTest.java
+++ b/mod-configuration-server/src/test/java/org/folio/rest/RestVerticleTest.java
@@ -81,12 +81,11 @@ public class RestVerticleTest {
         tClient.post(ta, response -> {
           if(422 == response.statusCode()){
             try {
-              tClient.post(null, responseHandler -> {
-                responseHandler.bodyHandler( body -> {
-                  System.out.println(body.toString());
-                  async.complete();
-                });
-              });
+              tClient.post(null, responseHandler ->
+                responseHandler.bodyHandler(body -> {
+                System.out.println(body.toString());
+                async.complete();
+              }));
             } catch (Exception e) {
               context.fail(e.getMessage());
             }
@@ -105,15 +104,13 @@ public class RestVerticleTest {
   @AfterClass
   public static void afterAll(TestContext context) {
     Async async = context.async();
-    tClient.delete( reply -> {
-      reply.bodyHandler( body2 -> {
-        System.out.println(body2.toString());
-        vertx.close(context.asyncAssertSuccess( res-> {
-          PostgresClient.stopEmbeddedPostgres();
-          async.complete();
-        }));
-      });
-    });
+    tClient.delete(reply -> reply.bodyHandler(body -> {
+      System.out.println(body.toString());
+      vertx.close(context.asyncAssertSuccess(res-> {
+        PostgresClient.stopEmbeddedPostgres();
+        async.complete();
+      }));
+    }));
 
     Locale.setDefault(oldLocale);
   }
@@ -336,9 +333,9 @@ public class RestVerticleTest {
       async.complete();
       context.fail(error.getMessage());
     }).handler(response -> {
-      response.headers().forEach( header -> {
-        System.out.println(header.getKey() + " " + header.getValue());
-      });
+      response.headers().forEach( header ->
+        System.out.println(header.getKey() + " " + header.getValue()));
+
       int statusCode = response.statusCode();
       if(method == HttpMethod.POST && statusCode == 201){
         try {


### PR DESCRIPTION
*Purpose*

In order to be able to easily add additional tests (e.g. for MODCONF-21)
the existing tests need splitting up and should be able to be run independently

https://issues.folio.org/browse/MODCONF-23

*Steps Involved*

* Split the existing test into separate independent chunks
* Start vert.x, embedded PostgreSQL and the module once per run of all
* Delete configuration records before each test
* Delete configuration audit records before each test

*Learning*
mod-configuration creates a set of default locale records for every tenant during activation. 

As the existing test relies on these records, these must not be deleted before each test runs and need to be compensated for in other tests. 

I've started conversations about moving these records to be optional sample records, at which point these limitations can be removed.

*TODO*
There is lots of refinement still to do, to reduce duplicate and improve readability of these tests. Some of this may happen as part of MODCONF-21. I wanted early feedback on this, before getting too deep into it.

* Add more tests for existing behaviour, e.g. fetching a single configuration record by ID, deletion etc
* Reduce duplication between HTTP request methods
* Reduce duplication in creating configuration records during the tests
* Improve diagnostics by using the junit assert and hamcrest matchers for checking (possible now that the vert.x TestContext has added the verify method)
* Remove the thread.sleep from within the existing tests