### PR TITLE
FOLIO-1027 enable lint-raml jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,9 +1,9 @@
 
-
 buildMvn {
   publishModDescriptor = 'yes'
   publishAPI = 'yes'
   mvnDeploy = 'yes'
+  runLintRamlCop = 'yes'
 
   doDocker = {
     buildJavaDocker {


### PR DESCRIPTION
Enable lint-raml with CI.

Developers can run the same script locally at `folio-tools/lint-raml/lint_raml_cop.py`

It will only report its findings, and not stop anything. With a PR, any errors will be shown, otherwise quiet.

See [folio-tools/lint-raml](https://github.com/folio-org/folio-tools/tree/master/lint-raml)