### PR TITLE
Unique module config name and code MODCONF-21

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
-## 4.0.4 unreleased
+## 5.0.0 unreleased
+
+* MODCONF-21 - Configuration records are unique for each module, config name and code
 * MODCONF-22 - use dereferenced kv_configuration.schema for metadata sorting
 
 ## 4.0.3 2018-04-24

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 * MODCONF-21 - Configuration records are enabled by default
 * MODCONF-22 - use dereferenced kv_configuration.schema for metadata sorting
 * Upgrades to RAML Module Builder 19.3.1
-* CQL queries for an unrecognised index report a 400 instead of 422
+* CQL queries including an unrecognised index report a 400 instead of 422
 
 ## 4.0.3 2018-04-24
 * MODCONF-17 - 500 and 422 errors while querying configurations/audit

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
-## 5.0.0 unreleased
+## 5.0.0 Unreleased
 
 * MODCONF-21 - Configuration records are unique for each module, config name and code
+* MODCONF-21 - Configuration records are enabled by default
 * MODCONF-22 - use dereferenced kv_configuration.schema for metadata sorting
 * Upgrades to RAML Module Builder 19.3.1
 * CQL queries for an unrecognised index report a 400 instead of 422

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * MODCONF-21 - Configuration records are unique for each module, config name and code
 * MODCONF-22 - use dereferenced kv_configuration.schema for metadata sorting
+* Upgrades to RAML Module Builder 19.3.1
+* CQL queries for an unrecognised index report a 400 instead of 422
 
 ## 4.0.3 2018-04-24
 * MODCONF-17 - 500 and 422 errors while querying configurations/audit

--- a/README.md
+++ b/README.md
@@ -5,8 +5,11 @@ Copyright (C) 2016-2018 The Open Library Foundation
 
 This software is distributed under the terms of the Apache License, Version 2.0. See the file ["LICENSE"](https://github.com/folio-org/mod-configuration/blob/master/LICENSE) for more information.
 
+## Purpose
 
-#### Configuration module based on the raml-module-builder and a set of raml and json schemas backed by a PostgreSQL async implementation
+Configuration module based on the raml-module-builder and a set of raml and json schemas backed by a PostgreSQL async implementation
+
+## Introduction
 
 This project is built using the raml-module-builder, using the PostgreSQL async client to implement some basic configuration APIs. It is highly recommended to read the [raml-module-builder README](https://github.com/folio-org/raml-module-builder/blob/master/README.md) since there are many features that the mod-configuration module inherits from the raml-module-builder framework.
 
@@ -105,6 +108,8 @@ To see an audit list:
 
 `http://<host>:<port>/configurations/audit`
 
+#### Querying audit records
+
 CQL syntax is also supported by the audit API
 
 ### <a id="local-apidocs"></a>Documentation of the Service's APIs
@@ -117,7 +122,6 @@ http://localhost:8085/apidocs/index.html?raml=raml/configuration/config.raml
 ### Examples
 
 Make sure to include appropriate headers as the runtime framework validates them.
-
 
 `Accept: application/json`
 
@@ -155,6 +159,37 @@ Deleting / Updating specific entries is possible as well - See circulation.raml 
 ```
 
 ## Additional information
+
+### Types of Configuration Records
+#### Tenant
+These are records which are not associated with a user (no `userId` property). 
+
+They represent a configuration setting for a tenant, and is the default if no user setting is in place (see validation section for what how records are intended to be matched). 
+
+#### User
+These are records which are associated user (a `userId` property is present).
+
+They represent a configuration setting for a specific user, which is considered to take precedence over a matching tenant setting (if present).
+
+### Defaults
+
+#### Enabled
+Configuration records are defaulted to be enabled (`enabled` is true) if the client does not provide a value for the `enabled` property.
+
+This applies to both newly created records, and records being replaced using PUT.
+
+### Validation
+As of version 5.0.0, configuration records are validated to be unique for combinations of certain properties.
+
+Disabled properties (`enabled` is false) are ignored during these checks.
+
+These checks are applied separately for tenant and user level records, in order for it to be possible to have user level record precedence for the same setting.
+
+#### Module and Config Name
+If no code is present, a setting is considered to be unique for the `module` and `configName` properties.
+
+#### Module, Config Name and Code
+If a code is present, a setting is considered to be unique for the `module`,  `configName` and `code` properties.
 
 ### Other documentation
 

--- a/README.md
+++ b/README.md
@@ -191,6 +191,14 @@ If no code is present, a setting is considered to be unique for the `module` and
 #### Module, Config Name and Code
 If a code is present, a setting is considered to be unique for the `module`,  `configName` and `code` properties.
 
+#### Implementation
+
+These checks are achieved by using four unique indexes. 
+
+Two of these are for the two variations above at the tenant level configurations and the other two at the user level. 
+
+See the [declarative schema](mod-configuration-server/src/main/resources/schema.json) for how these are defined.
+
 ### Other documentation
 
 The [raml-module-builder](https://github.com/folio-org/raml-module-builder) framework.

--- a/mod-configuration-client/pom.xml
+++ b/mod-configuration-client/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>mod-configuration</artifactId>
-    <version>4.0.4-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/mod-configuration-server/pom.xml
+++ b/mod-configuration-server/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>mod-configuration</artifactId>
-    <version>4.0.4-SNAPSHOT</version>
+    <version>5.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>mod-configuration-server</artifactId>
 

--- a/mod-configuration-server/pom.xml
+++ b/mod-configuration-server/pom.xml
@@ -49,7 +49,14 @@
           </environmentVariables>
         </configuration>
       </plugin>
-
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>0.8.0</version>
+        <configuration>
+          <excludes>**org.drools**</excludes>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>

--- a/mod-configuration-server/src/main/java/org/folio/rest/impl/ConfigAPI.java
+++ b/mod-configuration-server/src/main/java/org/folio/rest/impl/ConfigAPI.java
@@ -446,7 +446,8 @@ public class ConfigAPI implements ConfigurationsResource {
     else {
       return message.contains("config_data_module_configname_code_idx_unique")
         || message.contains("config_data_module_configname_idx_unique")
-        || message.contains("config_data_module_configname_code_userid_idx_unique");
+        || message.contains("config_data_module_configname_code_userid_idx_unique")
+        || message.contains("config_data_module_configname_userid_idx_unique");
     }
   }
 

--- a/mod-configuration-server/src/main/java/org/folio/rest/impl/ConfigAPI.java
+++ b/mod-configuration-server/src/main/java/org/folio/rest/impl/ConfigAPI.java
@@ -436,23 +436,23 @@ public class ConfigAPI implements ConfigurationsResource {
     //TODO: discriminate better the different unique constraints
     final String message = PgExceptionUtil.badRequestMessage(reply.cause());
 
-    //TODO: discriminate better the different unique constraints
     return message.contains("config_data_module_configname_code_idx_unique")
-      || message.contains("config_data_module_configname_idx_unique");
+      || message.contains("config_data_module_configname_idx_unique")
+      || message.contains("config_data_module_configname_code_userid_idx_unique");
   }
 
   private Errors uniqueModuleConfigAndCodeError(Config entity) {
-    Error error = new Error();
-
-    error.withMessage("Cannot have more than one record with the same module, config name and code")
+    final Error error = new Error()
+      .withMessage("Cannot have more than one tenant or user record with the same module, config name and code")
       .withAdditionalProperty("module", entity.getModule())
       .withAdditionalProperty("configName", entity.getConfigName())
-      .withAdditionalProperty("code", entity.getCode());
+      .withAdditionalProperty("code", entity.getCode())
+      .withAdditionalProperty("userId", entity.getUserId());
 
-    List<Error> errorList = new ArrayList<>();
+    final List<Error> errorList = new ArrayList<>();
     errorList.add(error);
 
-    Errors errors = new Errors();
+    final Errors errors = new Errors();
     errors.setErrors(errorList);
 
     return errors;

--- a/mod-configuration-server/src/main/java/org/folio/rest/impl/ConfigAPI.java
+++ b/mod-configuration-server/src/main/java/org/folio/rest/impl/ConfigAPI.java
@@ -455,18 +455,17 @@ public class ConfigAPI implements ConfigurationsResource {
       return false;
     }
 
-    //TODO: discriminate better the different unique constraints
     final String message = PgExceptionUtil.badRequestMessage(reply.cause());
 
     if(message == null) {
       return false;
     }
-    else {
-      return message.contains("config_data_module_configname_code_idx_unique")
-        || message.contains("config_data_module_configname_idx_unique")
-        || message.contains("config_data_module_configname_code_userid_idx_unique")
-        || message.contains("config_data_module_configname_userid_idx_unique");
-    }
+
+    //TODO: discriminate better the different unique constraints
+    return message.contains("config_data_module_configname_code_idx_unique")
+      || message.contains("config_data_module_configname_idx_unique")
+      || message.contains("config_data_module_configname_code_userid_idx_unique")
+      || message.contains("config_data_module_configname_userid_idx_unique");
   }
 
   private Errors uniqueModuleConfigAndCodeError(Config entity) {

--- a/mod-configuration-server/src/main/java/org/folio/rest/impl/ConfigAPI.java
+++ b/mod-configuration-server/src/main/java/org/folio/rest/impl/ConfigAPI.java
@@ -166,7 +166,8 @@ public class ConfigAPI implements ConfigurationsResource {
                 entity.setId((String) ret);
                 OutStream stream = new OutStream();
                 stream.setData(entity);
-                asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(PostConfigurationsEntriesResponse.withJsonCreated(
+                asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
+                  PostConfigurationsEntriesResponse.withJsonCreated(
                   LOCATION_PREFIX + ret, stream)));
               }
               else {
@@ -304,8 +305,8 @@ public class ConfigAPI implements ConfigurationsResource {
   @Validate
   @Override
   public void putConfigurationsEntriesByEntryId(String entryId, String lang, Config entity,
-                                                Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler,
-                                                Context vertxContext) throws Exception {
+      Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler,
+      Context vertxContext) throws Exception {
 
     vertxContext.runOnContext(v -> {
       System.out.println("sending... putConfigurationsTablesByTableId");
@@ -432,9 +433,12 @@ public class ConfigAPI implements ConfigurationsResource {
   }
 
   private boolean isNotUniqueModuleConfigAndCode(AsyncResult<String> reply) {
+    //TODO: discriminate better the different unique constraints
     final String message = PgExceptionUtil.badRequestMessage(reply.cause());
 
-    return message.contains("config_data_module_configname_code_idx_unique");
+    //TODO: discriminate better the different unique constraints
+    return message.contains("config_data_module_configname_code_idx_unique")
+      || message.contains("config_data_module_configname_idx_unique");
   }
 
   private Errors uniqueModuleConfigAndCodeError(Config entity) {

--- a/mod-configuration-server/src/main/java/org/folio/rest/impl/ConfigAPI.java
+++ b/mod-configuration-server/src/main/java/org/folio/rest/impl/ConfigAPI.java
@@ -433,12 +433,21 @@ public class ConfigAPI implements ConfigurationsResource {
   }
 
   private boolean isNotUniqueModuleConfigAndCode(AsyncResult<String> reply) {
+    if(reply == null) {
+      return false;
+    }
+
     //TODO: discriminate better the different unique constraints
     final String message = PgExceptionUtil.badRequestMessage(reply.cause());
 
-    return message.contains("config_data_module_configname_code_idx_unique")
-      || message.contains("config_data_module_configname_idx_unique")
-      || message.contains("config_data_module_configname_code_userid_idx_unique");
+    if(message == null) {
+      return false;
+    }
+    else {
+      return message.contains("config_data_module_configname_code_idx_unique")
+        || message.contains("config_data_module_configname_idx_unique")
+        || message.contains("config_data_module_configname_code_userid_idx_unique");
+    }
   }
 
   private Errors uniqueModuleConfigAndCodeError(Config entity) {

--- a/mod-configuration-server/src/main/java/org/folio/rest/impl/ConfigAPI.java
+++ b/mod-configuration-server/src/main/java/org/folio/rest/impl/ConfigAPI.java
@@ -107,17 +107,17 @@ public class ConfigAPI implements ConfigurationsResource {
                   configs.setConfigs(config);
                   configs.setResultInfo(reply.result().getResultInfo());
                   configs.setTotalRecords(reply.result().getResultInfo().getTotalRecords());
-                  asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(GetConfigurationsEntriesResponse.withJsonOK(
+                  asyncResultHandler.handle(succeededFuture(GetConfigurationsEntriesResponse.withJsonOK(
                     configs)));
                 }
                 else{
                   log.error(reply.cause().getMessage(), reply.cause());
-                  asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(GetConfigurationsEntriesResponse
+                  asyncResultHandler.handle(succeededFuture(GetConfigurationsEntriesResponse
                     .withPlainBadRequest(reply.cause().getMessage())));
                 }
               } catch (Exception e) {
                 log.error(e.getMessage(), e);
-                asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(GetConfigurationsEntriesResponse
+                asyncResultHandler.handle(succeededFuture(GetConfigurationsEntriesResponse
                   .withPlainInternalServerError(messages.getMessage(
                     lang, MessageConsts.InternalServerError))));
               }
@@ -132,7 +132,7 @@ public class ConfigAPI implements ConfigurationsResource {
         }
         log.error(e1.getMessage());
         Errors e = ValidationHelper.createValidationErrorMessage(field, "", e1.getMessage());
-        asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(GetConfigurationsEntriesResponse
+        asyncResultHandler.handle(succeededFuture(GetConfigurationsEntriesResponse
           .withJsonUnprocessableEntity(e)));
       }
       catch (Exception e) {
@@ -141,7 +141,7 @@ public class ConfigAPI implements ConfigurationsResource {
         if(e.getCause() != null && e.getCause().getClass().getSimpleName().endsWith("CQLParseException")){
           message = " CQL parse error " + e.getLocalizedMessage();
         }
-        asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(GetConfigurationsEntriesResponse
+        asyncResultHandler.handle(succeededFuture(GetConfigurationsEntriesResponse
           .withPlainInternalServerError(message)));
       }
     });
@@ -166,7 +166,7 @@ public class ConfigAPI implements ConfigurationsResource {
                 entity.setId((String) ret);
                 OutStream stream = new OutStream();
                 stream.setData(entity);
-                asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
+                asyncResultHandler.handle(succeededFuture(
                   PostConfigurationsEntriesResponse.withJsonCreated(
                   LOCATION_PREFIX + ret, stream)));
               }
@@ -179,20 +179,20 @@ public class ConfigAPI implements ConfigurationsResource {
                       .withJsonUnprocessableEntity(uniqueModuleConfigAndCodeError(entity))));
                 }
                 else {
-                  asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
+                  asyncResultHandler.handle(succeededFuture(
                     PostConfigurationsEntriesResponse.withPlainInternalServerError(
                       messages.getMessage(lang, MessageConsts.InternalServerError))));
                 }
               }
             } catch (Exception e) {
               log.error(e.getMessage(), e);
-              asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(PostConfigurationsEntriesResponse
+              asyncResultHandler.handle(succeededFuture(PostConfigurationsEntriesResponse
                 .withPlainInternalServerError(messages.getMessage(lang, MessageConsts.InternalServerError))));
             }
           });
       } catch (Exception e) {
         log.error(e.getMessage(), e);
-        asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(PostConfigurationsEntriesResponse
+        asyncResultHandler.handle(succeededFuture(PostConfigurationsEntriesResponse
           .withPlainInternalServerError(messages.getMessage(lang, MessageConsts.InternalServerError))));
       }
     });
@@ -219,35 +219,35 @@ public class ConfigAPI implements ConfigurationsResource {
                   @SuppressWarnings("unchecked")
                   List<Config> config = (List<Config>) reply.result().getResults();
                   if(config.isEmpty()){
-                    asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(GetConfigurationsEntriesByEntryIdResponse
+                    asyncResultHandler.handle(succeededFuture(GetConfigurationsEntriesByEntryIdResponse
                       .withPlainNotFound(entryId)));
                   }
                   else{
-                    asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(GetConfigurationsEntriesByEntryIdResponse
+                    asyncResultHandler.handle(succeededFuture(GetConfigurationsEntriesByEntryIdResponse
                       .withJsonOK(config.get(0))));
                   }
                 }
                 else{
                   log.error(reply.cause().getMessage(), reply.cause());
                   if(isInvalidUUID(reply.cause().getMessage())){
-                    asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(GetConfigurationsEntriesByEntryIdResponse
+                    asyncResultHandler.handle(succeededFuture(GetConfigurationsEntriesByEntryIdResponse
                       .withPlainNotFound(entryId)));
                   }
                   else{
-                    asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(GetConfigurationsEntriesByEntryIdResponse
+                    asyncResultHandler.handle(succeededFuture(GetConfigurationsEntriesByEntryIdResponse
                       .withPlainInternalServerError(messages.getMessage(lang, MessageConsts.InternalServerError) + " " +
                           reply.cause().getMessage())));
                   }
                 }
               } catch (Exception e) {
                 log.error(e.getMessage(), e);
-                asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(GetConfigurationsEntriesByEntryIdResponse
+                asyncResultHandler.handle(succeededFuture(GetConfigurationsEntriesByEntryIdResponse
                   .withPlainInternalServerError(messages.getMessage(lang, MessageConsts.InternalServerError))));
               }
         });
       } catch (Exception e) {
         log.error(e.getMessage(), e);
-        asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(GetConfigurationsEntriesByEntryIdResponse
+        asyncResultHandler.handle(succeededFuture(GetConfigurationsEntriesByEntryIdResponse
           .withPlainInternalServerError(messages.getMessage(lang, MessageConsts.InternalServerError))));
       }
     });
@@ -268,35 +268,35 @@ public class ConfigAPI implements ConfigurationsResource {
               try {
                 if(reply.succeeded()){
                   if(reply.result().getUpdated() == 1){
-                    asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(DeleteConfigurationsEntriesByEntryIdResponse
+                    asyncResultHandler.handle(succeededFuture(DeleteConfigurationsEntriesByEntryIdResponse
                       .withNoContent()));
                   }
                   else{
                     log.error(messages.getMessage(lang, MessageConsts.DeletedCountError, 1, reply.result().getUpdated()));
-                    asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(DeleteConfigurationsEntriesByEntryIdResponse
+                    asyncResultHandler.handle(succeededFuture(DeleteConfigurationsEntriesByEntryIdResponse
                       .withPlainNotFound(messages.getMessage(lang, MessageConsts.DeletedCountError,1 , reply.result().getUpdated()))));
                   }
                 }
                 else{
                   log.error(reply.cause());
                   if(isInvalidUUID(reply.cause().getMessage())){
-                    asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(DeleteConfigurationsEntriesByEntryIdResponse
+                    asyncResultHandler.handle(succeededFuture(DeleteConfigurationsEntriesByEntryIdResponse
                       .withPlainNotFound(entryId)));
                   }
                   else{
-                    asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(DeleteConfigurationsEntriesByEntryIdResponse
+                    asyncResultHandler.handle(succeededFuture(DeleteConfigurationsEntriesByEntryIdResponse
                       .withPlainInternalServerError(messages.getMessage(lang, MessageConsts.InternalServerError))));
                   }
                 }
               } catch (Exception e) {
                 log.error(e.getMessage(), e);
-                asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(DeleteConfigurationsEntriesByEntryIdResponse
+                asyncResultHandler.handle(succeededFuture(DeleteConfigurationsEntriesByEntryIdResponse
                   .withPlainInternalServerError(messages.getMessage(lang, MessageConsts.InternalServerError))));
               }
             });
         } catch (Exception e) {
           log.error(e.getMessage(), e);
-          asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(DeleteConfigurationsEntriesByEntryIdResponse
+          asyncResultHandler.handle(succeededFuture(DeleteConfigurationsEntriesByEntryIdResponse
             .withPlainInternalServerError(messages.getMessage(lang, MessageConsts.InternalServerError))));
         }
       });
@@ -310,36 +310,44 @@ public class ConfigAPI implements ConfigurationsResource {
 
     vertxContext.runOnContext(v -> {
       System.out.println("sending... putConfigurationsTablesByTableId");
-      String tenantId = TenantTool.calculateTenantId( okapiHeaders.get(RestVerticle.OKAPI_HEADER_TENANT) );
+      String tenantId = TenantTool.calculateTenantId( okapiHeaders.get(RestVerticle.OKAPI_HEADER_TENANT));
       try {
         PostgresClient.getInstance(vertxContext.owner(), tenantId).update(
           CONFIG_TABLE, entity, entryId,
           reply -> {
             try {
-              if(reply.succeeded()){
-                if(reply.result().getUpdated() == 0){
-                  asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(PutConfigurationsEntriesByEntryIdResponse
+              if(reply.succeeded()) {
+                if(reply.result().getUpdated() == 0) {
+                  asyncResultHandler.handle(succeededFuture(PutConfigurationsEntriesByEntryIdResponse
                     .withPlainInternalServerError(messages.getMessage(lang, MessageConsts.NoRecordsUpdated))));
                 }
                 else{
-                  asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(PutConfigurationsEntriesByEntryIdResponse
+                  asyncResultHandler.handle(succeededFuture(PutConfigurationsEntriesByEntryIdResponse
                     .withNoContent()));
                 }
               }
-              else{
-                log.error(reply.cause().getMessage());
-                asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(PutConfigurationsEntriesByEntryIdResponse
-                  .withPlainInternalServerError(messages.getMessage(lang, MessageConsts.InternalServerError))));
+              else {
+                log.error(reply.cause().getMessage(), reply.cause());
+
+                if(isNotUniqueModuleConfigAndCode(reply)) {
+                  asyncResultHandler.handle(succeededFuture(
+                    PutConfigurationsEntriesByEntryIdResponse
+                      .withJsonUnprocessableEntity(uniqueModuleConfigAndCodeError(entity))));
+                }
+                else {
+                  asyncResultHandler.handle(succeededFuture(PutConfigurationsEntriesByEntryIdResponse
+                    .withNoContent()));
+                }
               }
             } catch (Exception e) {
               log.error(e.getMessage(), e);
-              asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(PutConfigurationsEntriesByEntryIdResponse
+              asyncResultHandler.handle(succeededFuture(PutConfigurationsEntriesByEntryIdResponse
                 .withPlainInternalServerError(messages.getMessage(lang, MessageConsts.InternalServerError))));
             }
           });
       } catch (Exception e) {
         log.error(e.getMessage(), e);
-        asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(PutConfigurationsEntriesByEntryIdResponse
+        asyncResultHandler.handle(succeededFuture(PutConfigurationsEntriesByEntryIdResponse
           .withPlainInternalServerError(messages.getMessage(lang, MessageConsts.InternalServerError))));
       }
     });
@@ -380,18 +388,18 @@ public class ConfigAPI implements ConfigurationsResource {
                   List<Audit> auditList = (List<Audit>) reply.result().getResults();
                   auditRecords.setAudits(auditList);
                   auditRecords.setTotalRecords(reply.result().getResultInfo().getTotalRecords());
-                  asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(GetConfigurationsAuditResponse.withJsonOK(
+                  asyncResultHandler.handle(succeededFuture(GetConfigurationsAuditResponse.withJsonOK(
                     auditRecords)));
                 }
                 else{
                   log.error(reply.cause().getMessage(), reply.cause());
-                  asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(GetConfigurationsAuditResponse
+                  asyncResultHandler.handle(succeededFuture(GetConfigurationsAuditResponse
                     .withPlainInternalServerError(messages.getMessage(
                       lang, MessageConsts.InternalServerError))));
                 }
               } catch (Exception e) {
                 log.error(e.getMessage(), e);
-                asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(GetConfigurationsAuditResponse
+                asyncResultHandler.handle(succeededFuture(GetConfigurationsAuditResponse
                   .withPlainInternalServerError(messages.getMessage(
                     lang, MessageConsts.InternalServerError))));
               }
@@ -405,7 +413,7 @@ public class ConfigAPI implements ConfigurationsResource {
           field = field.substring(start+1, end);
         }
         Errors e = ValidationHelper.createValidationErrorMessage(field, "", e1.getMessage());
-        asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(GetConfigurationsEntriesResponse
+        asyncResultHandler.handle(succeededFuture(GetConfigurationsEntriesResponse
           .withJsonUnprocessableEntity(e)));
       }
       catch (Exception e) {
@@ -414,7 +422,7 @@ public class ConfigAPI implements ConfigurationsResource {
         if(e.getCause() != null && e.getCause().getClass().getSimpleName().endsWith("CQLParseException")){
           message = " CQL parse error " + e.getLocalizedMessage();
         }
-        asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(GetConfigurationsAuditResponse
+        asyncResultHandler.handle(succeededFuture(GetConfigurationsAuditResponse
           .withPlainInternalServerError(message)));
       }
     });
@@ -432,7 +440,7 @@ public class ConfigAPI implements ConfigurationsResource {
     }
   }
 
-  private boolean isNotUniqueModuleConfigAndCode(AsyncResult<String> reply) {
+  private <T> boolean isNotUniqueModuleConfigAndCode(AsyncResult<T> reply) {
     if(reply == null) {
       return false;
     }

--- a/mod-configuration-server/src/main/java/org/folio/rest/impl/ConfigAPI.java
+++ b/mod-configuration-server/src/main/java/org/folio/rest/impl/ConfigAPI.java
@@ -153,7 +153,9 @@ public class ConfigAPI implements ConfigurationsResource {
   @Validate
   @Override
   public void postConfigurationsEntries(String lang, Config entity, java.util.Map<String, String>okapiHeaders,
-      Handler<AsyncResult<Response>> asyncResultHandler, Context context) throws Exception {
+      Handler<AsyncResult<Response>> asyncResultHandler, Context context) {
+
+    defaultToEnabled(entity);
 
     context.runOnContext(v -> {
       try {
@@ -309,7 +311,9 @@ public class ConfigAPI implements ConfigurationsResource {
   @Override
   public void putConfigurationsEntriesByEntryId(String entryId, String lang, Config entity,
       Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler,
-      Context vertxContext) throws Exception {
+      Context vertxContext) {
+
+    defaultToEnabled(entity);
 
     vertxContext.runOnContext(v -> {
       log.debug("sending... putConfigurationsTablesByTableId");
@@ -480,5 +484,11 @@ public class ConfigAPI implements ConfigurationsResource {
     errors.setErrors(errorList);
 
     return errors;
+  }
+
+  private void defaultToEnabled(Config entity) {
+    if(entity.getEnabled() == null) {
+      entity.setEnabled(true);
+    }
   }
 }

--- a/mod-configuration-server/src/main/resources/data/locales.data
+++ b/mod-configuration-server/src/main/resources/data/locales.data
@@ -1,4 +1,3 @@
-{"module":"SETTINGS","configName":"locale","code":"system.timezone.en","description":"timezone","default": true,"enabled": true,"value": "GMT-04:00"}
 {"module":"SETTINGS","configName":"locale","code":"system.timezone.en","description":"timezone","default": true,"enabled": true,"value": "GMT-04:00" , "userId" : "joeshmoe"}
 {"module":"SETTINGS","configName":"locale","code":"system.timezone_date.en","description":"timezone date format","default": true,"enabled": true,"value": "dd/MM/yyyy"}
 {"module":"SETTINGS","configName":"locale","code":"system.timezone_time.en","description":"timezone time format","default": true,"enabled": true,"value": "HH:mm:ss a z"}

--- a/mod-configuration-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-configuration-server/src/main/resources/templates/db_scripts/schema.json
@@ -49,7 +49,7 @@
         },
         {
           "fieldName": "module, configName, code, userId",
-          "whereClause": "WHERE (jsonb->'code') is not null AND (jsonb->'userId') is not null",
+          "whereClause": "WHERE (jsonb->'code') is not null AND (jsonb->'userId') is not null AND (jsonb->>'enabled')::boolean is true",
           "tOps": "ADD"
         },
         {

--- a/mod-configuration-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-configuration-server/src/main/resources/templates/db_scripts/schema.json
@@ -36,6 +36,12 @@
           "removeAccents": false
         }
       ],
+      "uniqueIndex": [
+        {
+          "fieldName": "module, configName, code",
+          "tOps": "ADD"
+        }
+      ],
       "index": [
         {
           "fieldName": "module",

--- a/mod-configuration-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-configuration-server/src/main/resources/templates/db_scripts/schema.json
@@ -44,7 +44,7 @@
         },
         {
           "fieldName": "module, configName",
-          "whereClause": "WHERE ((jsonb->'code')) is null",
+          "whereClause": "WHERE ((jsonb->'code')) is null AND ((jsonb->'userId')) is null",
           "tOps": "ADD"
         }
       ],

--- a/mod-configuration-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-configuration-server/src/main/resources/templates/db_scripts/schema.json
@@ -39,6 +39,12 @@
       "uniqueIndex": [
         {
           "fieldName": "module, configName, code",
+          "whereClause": "WHERE ((jsonb->'code')) is not null",
+          "tOps": "ADD"
+        },
+        {
+          "fieldName": "module, configName",
+          "whereClause": "WHERE ((jsonb->'code')) is null",
           "tOps": "ADD"
         }
       ],

--- a/mod-configuration-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-configuration-server/src/main/resources/templates/db_scripts/schema.json
@@ -39,7 +39,7 @@
       "uniqueIndex": [
         {
           "fieldName": "module, configName, code",
-          "whereClause": "WHERE ((jsonb->'code')) is not null",
+          "whereClause": "WHERE ((jsonb->'code')) is not null AND ((jsonb->'userId')) is null",
           "tOps": "ADD"
         },
         {

--- a/mod-configuration-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-configuration-server/src/main/resources/templates/db_scripts/schema.json
@@ -54,7 +54,7 @@
         },
         {
           "fieldName": "module, configName, userId",
-          "whereClause": "WHERE (jsonb->'code') is null AND (jsonb->'userId') is not null",
+          "whereClause": "WHERE (jsonb->'code') is null AND (jsonb->'userId') is not null AND (jsonb->>'enabled')::boolean is true",
           "tOps": "ADD"
         }
       ],

--- a/mod-configuration-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-configuration-server/src/main/resources/templates/db_scripts/schema.json
@@ -51,6 +51,11 @@
           "fieldName": "module, configName, code, userId",
           "whereClause": "WHERE ((jsonb->'code')) is not null AND ((jsonb->'userId')) is not null",
           "tOps": "ADD"
+        },
+        {
+          "fieldName": "module, configName, userId",
+          "whereClause": "WHERE ((jsonb->'code')) is null AND ((jsonb->'userId')) is not null",
+          "tOps": "ADD"
         }
       ],
       "index": [

--- a/mod-configuration-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-configuration-server/src/main/resources/templates/db_scripts/schema.json
@@ -39,22 +39,22 @@
       "uniqueIndex": [
         {
           "fieldName": "module, configName, code",
-          "whereClause": "WHERE ((jsonb->'code')) is not null AND ((jsonb->'userId')) is null",
+          "whereClause": "WHERE (jsonb->'code') is not null AND (jsonb->'userId') is null AND (jsonb->>'enabled')::boolean is true",
           "tOps": "ADD"
         },
         {
           "fieldName": "module, configName",
-          "whereClause": "WHERE ((jsonb->'code')) is null AND ((jsonb->'userId')) is null",
+          "whereClause": "WHERE (jsonb->'code') is null AND (jsonb->'userId') is null",
           "tOps": "ADD"
         },
         {
           "fieldName": "module, configName, code, userId",
-          "whereClause": "WHERE ((jsonb->'code')) is not null AND ((jsonb->'userId')) is not null",
+          "whereClause": "WHERE (jsonb->'code') is not null AND (jsonb->'userId') is not null",
           "tOps": "ADD"
         },
         {
           "fieldName": "module, configName, userId",
-          "whereClause": "WHERE ((jsonb->'code')) is null AND ((jsonb->'userId')) is not null",
+          "whereClause": "WHERE (jsonb->'code') is null AND (jsonb->'userId') is not null",
           "tOps": "ADD"
         }
       ],

--- a/mod-configuration-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-configuration-server/src/main/resources/templates/db_scripts/schema.json
@@ -46,6 +46,11 @@
           "fieldName": "module, configName",
           "whereClause": "WHERE ((jsonb->'code')) is null AND ((jsonb->'userId')) is null",
           "tOps": "ADD"
+        },
+        {
+          "fieldName": "module, configName, code, userId",
+          "whereClause": "WHERE ((jsonb->'code')) is not null AND ((jsonb->'userId')) is not null",
+          "tOps": "ADD"
         }
       ],
       "index": [

--- a/mod-configuration-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-configuration-server/src/main/resources/templates/db_scripts/schema.json
@@ -44,7 +44,7 @@
         },
         {
           "fieldName": "module, configName",
-          "whereClause": "WHERE (jsonb->'code') is null AND (jsonb->'userId') is null",
+          "whereClause": "WHERE (jsonb->'code') is null AND (jsonb->'userId') is null AND (jsonb->>'enabled')::boolean is true",
           "tOps": "ADD"
         },
         {

--- a/mod-configuration-server/src/test/java/org/folio/rest/RestVerticleTest.java
+++ b/mod-configuration-server/src/test/java/org/folio/rest/RestVerticleTest.java
@@ -138,7 +138,7 @@ public class RestVerticleTest {
   public void canCreateConfigurationRecord(TestContext testContext) {
     final Async async = testContext.async();
 
-    JsonObject configRecord = new ConfigurationRecordBuilder().configurationRecord(
+    JsonObject configRecord = new ConfigurationRecordBuilder().create(
       "audioAlertsEnabled",
       true,
       "Whether audio alerts should be made during check out");
@@ -233,7 +233,7 @@ public class RestVerticleTest {
 
     final ArrayList<CompletableFuture<Response>> allCreated = new ArrayList<>();
 
-    JsonObject firstConfigRecord = new ConfigurationRecordBuilder().configurationRecord(
+    JsonObject firstConfigRecord = new ConfigurationRecordBuilder().create(
       "audioAlertsEnabled",
       true,
       "Whether audio alerts should be made during check out");
@@ -242,7 +242,7 @@ public class RestVerticleTest {
       "http://localhost:" + port + "/configurations/entries",
       firstConfigRecord.encodePrettily()));
 
-    JsonObject secondConfigRecord = new ConfigurationRecordBuilder().configurationRecord(
+    JsonObject secondConfigRecord = new ConfigurationRecordBuilder().create(
       "checkoutTimeoutDuration",
       3,
       "How long the timeout for a check out session should be");
@@ -282,7 +282,7 @@ public class RestVerticleTest {
 
     final Async async = testContext.async();
 
-    JsonObject firstConfigRecord = new ConfigurationRecordBuilder().configurationRecord(
+    JsonObject firstConfigRecord = new ConfigurationRecordBuilder().create(
       "audioAlertsEnabled",
       true,
       "Whether audio alerts should be made during check out");
@@ -294,7 +294,7 @@ public class RestVerticleTest {
     //Make sure the first record is created before the second
     firstRecordCreated.get(5, TimeUnit.SECONDS);
 
-    JsonObject secondConfigRecord = new ConfigurationRecordBuilder().configurationRecord(
+    JsonObject secondConfigRecord = new ConfigurationRecordBuilder().create(
       "checkoutTimeoutDuration",
       3,
       "How long the timeout for a check out session should be");

--- a/mod-configuration-server/src/test/java/org/folio/rest/RestVerticleTest.java
+++ b/mod-configuration-server/src/test/java/org/folio/rest/RestVerticleTest.java
@@ -138,7 +138,7 @@ public class RestVerticleTest {
   public void canCreateConfigurationRecord(TestContext testContext) {
     final Async async = testContext.async();
 
-    JsonObject configRecord = ConfigurationRecordBuilder.configurationRecord(
+    JsonObject configRecord = new ConfigurationRecordBuilder().configurationRecord(
       "audioAlertsEnabled",
       true,
       "Whether audio alerts should be made during check out");
@@ -233,7 +233,7 @@ public class RestVerticleTest {
 
     final ArrayList<CompletableFuture<Response>> allCreated = new ArrayList<>();
 
-    JsonObject firstConfigRecord = ConfigurationRecordBuilder.configurationRecord(
+    JsonObject firstConfigRecord = new ConfigurationRecordBuilder().configurationRecord(
       "audioAlertsEnabled",
       true,
       "Whether audio alerts should be made during check out");
@@ -242,7 +242,7 @@ public class RestVerticleTest {
       "http://localhost:" + port + "/configurations/entries",
       firstConfigRecord.encodePrettily()));
 
-    JsonObject secondConfigRecord = ConfigurationRecordBuilder.configurationRecord(
+    JsonObject secondConfigRecord = new ConfigurationRecordBuilder().configurationRecord(
       "checkoutTimeoutDuration",
       3,
       "How long the timeout for a check out session should be");
@@ -282,7 +282,7 @@ public class RestVerticleTest {
 
     final Async async = testContext.async();
 
-    JsonObject firstConfigRecord = ConfigurationRecordBuilder.configurationRecord(
+    JsonObject firstConfigRecord = new ConfigurationRecordBuilder().configurationRecord(
       "audioAlertsEnabled",
       true,
       "Whether audio alerts should be made during check out");
@@ -294,7 +294,7 @@ public class RestVerticleTest {
     //Make sure the first record is created before the second
     firstRecordCreated.get(5, TimeUnit.SECONDS);
 
-    JsonObject secondConfigRecord = ConfigurationRecordBuilder.configurationRecord(
+    JsonObject secondConfigRecord = new ConfigurationRecordBuilder().configurationRecord(
       "checkoutTimeoutDuration",
       3,
       "How long the timeout for a check out session should be");

--- a/mod-configuration-server/src/test/java/org/folio/rest/RestVerticleTest.java
+++ b/mod-configuration-server/src/test/java/org/folio/rest/RestVerticleTest.java
@@ -259,6 +259,41 @@ public class RestVerticleTest {
   }
 
   @Test
+  public void canCreateMultipleConfigurationRecordsWithSameConfigNameAndDifferentModuleWithoutCode(
+    TestContext testContext) {
+    final Async async = testContext.async();
+
+    JsonObject firstConfigRecord = new ConfigurationRecordBuilder()
+      .withModuleName("CHECKOUT")
+      .withConfigName("main_settings")
+      .withValue("some value")
+      .create();
+
+    final CompletableFuture<Response> firstRecordCompleted = post(
+      "http://localhost:" + port + "/configurations/entries",
+      firstConfigRecord.encodePrettily());
+
+    JsonObject secondConfigRecord = new ConfigurationRecordBuilder()
+      .withModuleName("RENEWAL")
+      .withConfigName("main_settings")
+      .withValue("some other value")
+      .create();
+
+    final CompletableFuture<Response> secondRecordCompleted = post(
+      "http://localhost:" + port + "/configurations/entries",
+      secondConfigRecord.encodePrettily());
+
+    List<CompletableFuture<Response>> allRecordsFutures = new ArrayList<>();
+    allRecordsFutures.add(firstRecordCompleted);
+    allRecordsFutures.add(secondRecordCompleted);
+
+    CompletableFuture<Void> allRecordsCompleted = allOf(allRecordsFutures);
+
+    allRecordsCompleted.thenAccept(v ->
+      checkAllRecordsCreated(allRecordsFutures, testContext, async));
+  }
+
+  @Test
   public void canGetConfigurationRecords(TestContext testContext) {
     final Async async = testContext.async();
 

--- a/mod-configuration-server/src/test/java/org/folio/rest/RestVerticleTest.java
+++ b/mod-configuration-server/src/test/java/org/folio/rest/RestVerticleTest.java
@@ -23,6 +23,7 @@ import org.folio.rest.jaxrs.model.TenantAttributes;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.security.AES;
 import org.folio.rest.tools.utils.NetworkUtils;
+import org.folio.support.ConfigurationRecordExamples;
 import org.folio.support.builders.ConfigurationRecordBuilder;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -139,7 +140,7 @@ public class RestVerticleTest {
   public void canCreateConfigurationRecord(TestContext testContext) {
     final Async async = testContext.async();
 
-    JsonObject configRecord = audioAlertsExample().create();
+    JsonObject configRecord = ConfigurationRecordExamples.audioAlertsExample().create();
 
     final CompletableFuture<Response> postCompleted = post(
       "http://localhost:" + port + "/configurations/entries",
@@ -458,13 +459,13 @@ public class RestVerticleTest {
 
     final ArrayList<CompletableFuture<Response>> allCreated = new ArrayList<>();
 
-    JsonObject firstConfigRecord = audioAlertsExample().create();
+    JsonObject firstConfigRecord = ConfigurationRecordExamples.audioAlertsExample().create();
 
     allCreated.add(post(
       "http://localhost:" + port + "/configurations/entries",
       firstConfigRecord.encodePrettily()));
 
-    JsonObject secondConfigRecord = timeOutDurationExample().create();
+    JsonObject secondConfigRecord = ConfigurationRecordExamples.timeOutDurationExample().create();
 
     allCreated.add(post(
       "http://localhost:" + port + "/configurations/entries",
@@ -501,7 +502,7 @@ public class RestVerticleTest {
 
     final Async async = testContext.async();
 
-    JsonObject firstConfigRecord = audioAlertsExample().create();
+    JsonObject firstConfigRecord = ConfigurationRecordExamples.audioAlertsExample().create();
 
     final CompletableFuture<Response> firstRecordCreated = post(
       "http://localhost:" + port + "/configurations/entries",
@@ -510,7 +511,7 @@ public class RestVerticleTest {
     //Make sure the first record is created before the second
     firstRecordCreated.get(5, TimeUnit.SECONDS);
 
-    JsonObject secondConfigRecord = timeOutDurationExample().create();
+    JsonObject secondConfigRecord = ConfigurationRecordExamples.timeOutDurationExample().create();
 
     final CompletableFuture<Response> secondRecordCreated = post(
       "http://localhost:" + port + "/configurations/entries",
@@ -948,23 +949,5 @@ public class RestVerticleTest {
     finally {
       async.complete();
     }
-  }
-
-  private static ConfigurationRecordBuilder timeOutDurationExample() {
-    return new ConfigurationRecordBuilder()
-      .withModuleName("CHECKOUT")
-      .withConfigName("other_settings")
-      .withCode("checkoutTimeoutDuration")
-      .withValue(3)
-      .withDescription("How long the timeout for a check out session should be");
-  }
-
-  private static ConfigurationRecordBuilder audioAlertsExample() {
-    return new ConfigurationRecordBuilder()
-      .withModuleName("CHECKOUT")
-      .withConfigName("other_settings")
-      .withCode("audioAlertsEnabled")
-      .withValue(true)
-      .withDescription("Whether audio alerts should be made during check out");
   }
 }

--- a/mod-configuration-server/src/test/java/org/folio/rest/RestVerticleTest.java
+++ b/mod-configuration-server/src/test/java/org/folio/rest/RestVerticleTest.java
@@ -22,6 +22,7 @@ import org.folio.rest.jaxrs.model.TenantAttributes;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.security.AES;
 import org.folio.rest.tools.utils.NetworkUtils;
+import org.folio.support.builders.ConfigurationRecordBuilder;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -137,7 +138,7 @@ public class RestVerticleTest {
   public void canCreateConfigurationRecord(TestContext testContext) {
     final Async async = testContext.async();
 
-    JsonObject configRecord = configurationRecord(
+    JsonObject configRecord = ConfigurationRecordBuilder.configurationRecord(
       "audioAlertsEnabled",
       true,
       "Whether audio alerts should be made during check out");
@@ -232,7 +233,7 @@ public class RestVerticleTest {
 
     final ArrayList<CompletableFuture<Response>> allCreated = new ArrayList<>();
 
-    JsonObject firstConfigRecord = configurationRecord(
+    JsonObject firstConfigRecord = ConfigurationRecordBuilder.configurationRecord(
       "audioAlertsEnabled",
       true,
       "Whether audio alerts should be made during check out");
@@ -241,7 +242,7 @@ public class RestVerticleTest {
       "http://localhost:" + port + "/configurations/entries",
       firstConfigRecord.encodePrettily()));
 
-    JsonObject secondConfigRecord = configurationRecord(
+    JsonObject secondConfigRecord = ConfigurationRecordBuilder.configurationRecord(
       "checkoutTimeoutDuration",
       3,
       "How long the timeout for a check out session should be");
@@ -281,7 +282,7 @@ public class RestVerticleTest {
 
     final Async async = testContext.async();
 
-    JsonObject firstConfigRecord = configurationRecord(
+    JsonObject firstConfigRecord = ConfigurationRecordBuilder.configurationRecord(
       "audioAlertsEnabled",
       true,
       "Whether audio alerts should be made during check out");
@@ -293,7 +294,7 @@ public class RestVerticleTest {
     //Make sure the first record is created before the second
     firstRecordCreated.get(5, TimeUnit.SECONDS);
 
-    JsonObject secondConfigRecord = configurationRecord(
+    JsonObject secondConfigRecord = ConfigurationRecordBuilder.configurationRecord(
       "checkoutTimeoutDuration",
       3,
       "How long the timeout for a check out session should be");
@@ -707,18 +708,5 @@ public class RestVerticleTest {
     List<CompletableFuture<T>> allFutures) {
 
     return CompletableFuture.allOf(allFutures.toArray(new CompletableFuture<?>[] { }));
-  }
-
-  private JsonObject configurationRecord(
-    String code,
-    Object value,
-    String description) {
-
-    return new JsonObject()
-      .put("module", "CHECKOUT")
-      .put("configName", "other_settings")
-      .put("description", description)
-      .put("code", code)
-      .put("value", value);
   }
 }

--- a/mod-configuration-server/src/test/java/org/folio/rest/RestVerticleTest.java
+++ b/mod-configuration-server/src/test/java/org/folio/rest/RestVerticleTest.java
@@ -264,13 +264,6 @@ public class RestVerticleTest {
     });
   }
 
-  private ConfigurationRecordBuilder audioAlertsExample() {
-    return new ConfigurationRecordBuilder()
-      .withCode("audioAlertsEnabled")
-      .withValue(true)
-      .withDescription("Whether audio alerts should be made during check out");
-  }
-
   @Test
   public void canSortConfigurationRecordsByCreatedDate(TestContext testContext)
     throws UnsupportedEncodingException,
@@ -327,13 +320,6 @@ public class RestVerticleTest {
           async.complete();
         }
       });
-  }
-
-  private ConfigurationRecordBuilder timeOutDurationExample() {
-    return new ConfigurationRecordBuilder()
-      .withCode("checkoutTimeoutDuration")
-      .withValue(3)
-      .withDescription("How long the timeout for a check out session should be");
   }
 
   @Test
@@ -707,5 +693,21 @@ public class RestVerticleTest {
     List<CompletableFuture<T>> allFutures) {
 
     return CompletableFuture.allOf(allFutures.toArray(new CompletableFuture<?>[] { }));
+  }
+
+  private static ConfigurationRecordBuilder timeOutDurationExample() {
+    return new ConfigurationRecordBuilder()
+      .withModuleName("CHECKOUT")
+      .withCode("checkoutTimeoutDuration")
+      .withValue(3)
+      .withDescription("How long the timeout for a check out session should be");
+  }
+
+  private static ConfigurationRecordBuilder audioAlertsExample() {
+    return new ConfigurationRecordBuilder()
+      .withModuleName("CHECKOUT")
+      .withCode("audioAlertsEnabled")
+      .withValue(true)
+      .withDescription("Whether audio alerts should be made during check out");
   }
 }

--- a/mod-configuration-server/src/test/java/org/folio/rest/RestVerticleTest.java
+++ b/mod-configuration-server/src/test/java/org/folio/rest/RestVerticleTest.java
@@ -1018,6 +1018,45 @@ public class RestVerticleTest {
   }
 
   @Test
+  public void canCreateMultipleDisabledTenantConfigurationRecordsWithoutCode(
+    TestContext testContext) {
+
+    final Async async = testContext.async();
+
+    List<CompletableFuture<Response>> allRecordsFutures = new ArrayList<>();
+
+    final ConfigurationRecordBuilder baselineSetting = new ConfigurationRecordBuilder()
+      .withModuleName("CHECKOUT")
+      .withConfigName("main_settings")
+      .withNoCode()
+      .withValue("some value");
+
+    JsonObject tenantConfigRecord = baselineSetting
+      .create();
+
+    allRecordsFutures.add(createConfigRecord(tenantConfigRecord));
+
+    JsonObject firstDisabledConfigRecord = baselineSetting
+      .withValue("another value")
+      .disabled()
+      .create();
+
+    allRecordsFutures.add(createConfigRecord(firstDisabledConfigRecord));
+
+    JsonObject secondDisabledConfigRecord = baselineSetting
+      .withValue("yet another value")
+      .disabled()
+      .create();
+
+    allRecordsFutures.add(createConfigRecord(secondDisabledConfigRecord));
+
+    CompletableFuture<Void> allRecordsCompleted = allOf(allRecordsFutures);
+
+    allRecordsCompleted.thenAccept(v ->
+      checkAllRecordsCreated(allRecordsFutures, testContext, async));
+  }
+
+  @Test
   public void canGetConfigurationRecords(TestContext testContext) {
     final Async async = testContext.async();
 

--- a/mod-configuration-server/src/test/java/org/folio/rest/RestVerticleTest.java
+++ b/mod-configuration-server/src/test/java/org/folio/rest/RestVerticleTest.java
@@ -137,12 +137,10 @@ public class RestVerticleTest {
   public void canCreateConfigurationRecord(TestContext testContext) {
     final Async async = testContext.async();
 
-    JsonObject configRecord = new JsonObject()
-      .put("module", "CHECKOUT")
-      .put("configName", "other_settings")
-      .put("description", "Whether audio alerts should be made during ckeckout")
-      .put("code", "audioAlertsEnabled")
-      .put("value", true);
+    JsonObject configRecord = configurationRecord(
+      "audioAlertsEnabled",
+      true,
+      "Whether audio alerts should be made during check out");
 
     final CompletableFuture<Response> postCompleted = post(
       "http://localhost:" + port + "/configurations/entries",
@@ -234,23 +232,19 @@ public class RestVerticleTest {
 
     final ArrayList<CompletableFuture<Response>> allCreated = new ArrayList<>();
 
-    JsonObject firstConfigRecord = new JsonObject()
-      .put("module", "CHECKOUT")
-      .put("configName", "other_settings")
-      .put("description", "Whether audio alerts should be made during ckeckout")
-      .put("code", "audioAlertsEnabled")
-      .put("value", true);
+    JsonObject firstConfigRecord = configurationRecord(
+      "audioAlertsEnabled",
+      true,
+      "Whether audio alerts should be made during check out");
 
     allCreated.add(post(
       "http://localhost:" + port + "/configurations/entries",
       firstConfigRecord.encodePrettily()));
 
-    JsonObject secondConfigRecord = new JsonObject()
-      .put("module", "CHECKOUT")
-      .put("configName", "other_settings")
-      .put("description", "Whether audio alerts should be made during ckeckout")
-      .put("code", "checkoutTimeoutDuration")
-      .put("value", 3);
+    JsonObject secondConfigRecord = configurationRecord(
+      "checkoutTimeoutDuration",
+      3,
+      "How long the timeout for a check out session should be");
 
     allCreated.add(post(
       "http://localhost:" + port + "/configurations/entries",
@@ -287,12 +281,10 @@ public class RestVerticleTest {
 
     final Async async = testContext.async();
 
-    JsonObject firstConfigRecord = new JsonObject()
-      .put("module", "CHECKOUT")
-      .put("configName", "other_settings")
-      .put("description", "Whether audio alerts should be made during ckeckout")
-      .put("code", "audioAlertsEnabled")
-      .put("value", true);
+    JsonObject firstConfigRecord = configurationRecord(
+      "audioAlertsEnabled",
+      true,
+      "Whether audio alerts should be made during check out");
 
     final CompletableFuture<Response> firstRecordCreated = post(
       "http://localhost:" + port + "/configurations/entries",
@@ -301,12 +293,10 @@ public class RestVerticleTest {
     //Make sure the first record is created before the second
     firstRecordCreated.get(5, TimeUnit.SECONDS);
 
-    JsonObject secondConfigRecord = new JsonObject()
-      .put("module", "CHECKOUT")
-      .put("configName", "other_settings")
-      .put("description", "Whether audio alerts should be made during ckeckout")
-      .put("code", "checkoutTimeoutDuration")
-      .put("value", 3);
+    JsonObject secondConfigRecord = configurationRecord(
+      "checkoutTimeoutDuration",
+      3,
+      "How long the timeout for a check out session should be");
 
     final CompletableFuture<Response> secondRecordCreated = post(
       "http://localhost:" + port + "/configurations/entries",
@@ -717,5 +707,18 @@ public class RestVerticleTest {
     List<CompletableFuture<T>> allFutures) {
 
     return CompletableFuture.allOf(allFutures.toArray(new CompletableFuture<?>[] { }));
+  }
+
+  private JsonObject configurationRecord(
+    String code,
+    Object value,
+    String description) {
+
+    return new JsonObject()
+      .put("module", "CHECKOUT")
+      .put("configName", "other_settings")
+      .put("description", description)
+      .put("code", code)
+      .put("value", value);
   }
 }

--- a/mod-configuration-server/src/test/java/org/folio/rest/RestVerticleTest.java
+++ b/mod-configuration-server/src/test/java/org/folio/rest/RestVerticleTest.java
@@ -225,7 +225,9 @@ public class RestVerticleTest {
   }
 
   @Test
-  public void canCreateMultipleConfigurationRecordsWithoutCode(TestContext testContext) {
+  public void canCreateMultipleConfigurationRecordsWithDifferentConfigNameWithoutCode(
+    TestContext testContext) {
+
     final Async async = testContext.async();
 
     JsonObject firstConfigRecord = new ConfigurationRecordBuilder()
@@ -259,7 +261,7 @@ public class RestVerticleTest {
   }
 
   @Test
-  public void canCreateMultipleConfigurationRecordsWithSameConfigNameAndDifferentModuleWithoutCode(
+  public void canCreateMultipleConfigurationRecordsWithDifferentModuleWithoutCode(
     TestContext testContext) {
     final Async async = testContext.async();
 
@@ -276,6 +278,43 @@ public class RestVerticleTest {
     JsonObject secondConfigRecord = new ConfigurationRecordBuilder()
       .withModuleName("RENEWAL")
       .withConfigName("main_settings")
+      .withValue("some other value")
+      .create();
+
+    final CompletableFuture<Response> secondRecordCompleted = post(
+      "http://localhost:" + port + "/configurations/entries",
+      secondConfigRecord.encodePrettily());
+
+    List<CompletableFuture<Response>> allRecordsFutures = new ArrayList<>();
+    allRecordsFutures.add(firstRecordCompleted);
+    allRecordsFutures.add(secondRecordCompleted);
+
+    CompletableFuture<Void> allRecordsCompleted = allOf(allRecordsFutures);
+
+    allRecordsCompleted.thenAccept(v ->
+      checkAllRecordsCreated(allRecordsFutures, testContext, async));
+  }
+
+  @Test
+  public void canCreateMultipleConfigurationRecordsWithDifferentConfigName(
+    TestContext testContext) {
+    final Async async = testContext.async();
+
+    JsonObject firstConfigRecord = new ConfigurationRecordBuilder()
+      .withModuleName("CHECKOUT")
+      .withConfigName("main_settings")
+      .withCode("first_setting")
+      .withValue("some value")
+      .create();
+
+    final CompletableFuture<Response> firstRecordCompleted = post(
+      "http://localhost:" + port + "/configurations/entries",
+      firstConfigRecord.encodePrettily());
+
+    JsonObject secondConfigRecord = new ConfigurationRecordBuilder()
+      .withModuleName("CHECKOUT")
+      .withConfigName("main_settings")
+      .withCode("second_setting")
       .withValue("some other value")
       .create();
 

--- a/mod-configuration-server/src/test/java/org/folio/rest/RestVerticleTest.java
+++ b/mod-configuration-server/src/test/java/org/folio/rest/RestVerticleTest.java
@@ -698,6 +698,7 @@ public class RestVerticleTest {
   private static ConfigurationRecordBuilder timeOutDurationExample() {
     return new ConfigurationRecordBuilder()
       .withModuleName("CHECKOUT")
+      .withConfigName("other_settings")
       .withCode("checkoutTimeoutDuration")
       .withValue(3)
       .withDescription("How long the timeout for a check out session should be");
@@ -706,6 +707,7 @@ public class RestVerticleTest {
   private static ConfigurationRecordBuilder audioAlertsExample() {
     return new ConfigurationRecordBuilder()
       .withModuleName("CHECKOUT")
+      .withConfigName("other_settings")
       .withCode("audioAlertsEnabled")
       .withValue(true)
       .withDescription("Whether audio alerts should be made during check out");

--- a/mod-configuration-server/src/test/java/org/folio/rest/RestVerticleTest.java
+++ b/mod-configuration-server/src/test/java/org/folio/rest/RestVerticleTest.java
@@ -138,11 +138,7 @@ public class RestVerticleTest {
   public void canCreateConfigurationRecord(TestContext testContext) {
     final Async async = testContext.async();
 
-    JsonObject configRecord = new ConfigurationRecordBuilder()
-      .withCode("audioAlertsEnabled")
-      .withValue(true)
-      .withDescription("Whether audio alerts should be made during check out")
-      .create();
+    JsonObject configRecord = audioAlertsExample().create();
 
     final CompletableFuture<Response> postCompleted = post(
       "http://localhost:" + port + "/configurations/entries",
@@ -234,21 +230,13 @@ public class RestVerticleTest {
 
     final ArrayList<CompletableFuture<Response>> allCreated = new ArrayList<>();
 
-    JsonObject firstConfigRecord = new ConfigurationRecordBuilder()
-      .withCode("audioAlertsEnabled")
-      .withValue(true)
-      .withDescription("Whether audio alerts should be made during check out")
-      .create();
+    JsonObject firstConfigRecord = audioAlertsExample().create();
 
     allCreated.add(post(
       "http://localhost:" + port + "/configurations/entries",
       firstConfigRecord.encodePrettily()));
 
-    JsonObject secondConfigRecord = new ConfigurationRecordBuilder()
-      .withCode("checkoutTimeoutDuration")
-      .withValue(3)
-      .withDescription("How long the timeout for a check out session should be")
-      .create();
+    JsonObject secondConfigRecord = timeOutDurationExample().create();
 
     allCreated.add(post(
       "http://localhost:" + port + "/configurations/entries",
@@ -276,6 +264,13 @@ public class RestVerticleTest {
     });
   }
 
+  private ConfigurationRecordBuilder audioAlertsExample() {
+    return new ConfigurationRecordBuilder()
+      .withCode("audioAlertsEnabled")
+      .withValue(true)
+      .withDescription("Whether audio alerts should be made during check out");
+  }
+
   @Test
   public void canSortConfigurationRecordsByCreatedDate(TestContext testContext)
     throws UnsupportedEncodingException,
@@ -285,11 +280,7 @@ public class RestVerticleTest {
 
     final Async async = testContext.async();
 
-    JsonObject firstConfigRecord = new ConfigurationRecordBuilder()
-      .withCode("audioAlertsEnabled")
-      .withValue(true)
-      .withDescription("Whether audio alerts should be made during check out")
-      .create();
+    JsonObject firstConfigRecord = audioAlertsExample().create();
 
     final CompletableFuture<Response> firstRecordCreated = post(
       "http://localhost:" + port + "/configurations/entries",
@@ -298,11 +289,7 @@ public class RestVerticleTest {
     //Make sure the first record is created before the second
     firstRecordCreated.get(5, TimeUnit.SECONDS);
 
-    JsonObject secondConfigRecord = new ConfigurationRecordBuilder()
-      .withCode("checkoutTimeoutDuration")
-      .withValue(3)
-      .withDescription("How long the timeout for a check out session should be")
-      .create();
+    JsonObject secondConfigRecord = timeOutDurationExample().create();
 
     final CompletableFuture<Response> secondRecordCreated = post(
       "http://localhost:" + port + "/configurations/entries",
@@ -340,6 +327,13 @@ public class RestVerticleTest {
           async.complete();
         }
       });
+  }
+
+  private ConfigurationRecordBuilder timeOutDurationExample() {
+    return new ConfigurationRecordBuilder()
+      .withCode("checkoutTimeoutDuration")
+      .withValue(3)
+      .withDescription("How long the timeout for a check out session should be");
   }
 
   @Test

--- a/mod-configuration-server/src/test/java/org/folio/rest/RestVerticleTest.java
+++ b/mod-configuration-server/src/test/java/org/folio/rest/RestVerticleTest.java
@@ -992,8 +992,7 @@ public class RestVerticleTest {
       .withCode("example_setting")
       .withValue("some value");
 
-    JsonObject tenantConfigRecord = baselineSetting
-      .create();
+    JsonObject tenantConfigRecord = baselineSetting.create();
 
     allRecordsFutures.add(createConfigRecord(tenantConfigRecord));
 
@@ -1031,8 +1030,7 @@ public class RestVerticleTest {
       .withNoCode()
       .withValue("some value");
 
-    JsonObject tenantConfigRecord = baselineSetting
-      .create();
+    JsonObject tenantConfigRecord = baselineSetting.create();
 
     allRecordsFutures.add(createConfigRecord(tenantConfigRecord));
 
@@ -1073,8 +1071,48 @@ public class RestVerticleTest {
       .withValue("some value")
       .forUser(userId);
 
-    JsonObject tenantConfigRecord = baselineSetting
+    JsonObject tenantConfigRecord = baselineSetting.create();
+
+    allRecordsFutures.add(createConfigRecord(tenantConfigRecord));
+
+    JsonObject firstDisabledConfigRecord = baselineSetting
+      .withValue("another value")
+      .disabled()
       .create();
+
+    allRecordsFutures.add(createConfigRecord(firstDisabledConfigRecord));
+
+    JsonObject secondDisabledConfigRecord = baselineSetting
+      .withValue("yet another value")
+      .disabled()
+      .create();
+
+    allRecordsFutures.add(createConfigRecord(secondDisabledConfigRecord));
+
+    CompletableFuture<Void> allRecordsCompleted = allOf(allRecordsFutures);
+
+    allRecordsCompleted.thenAccept(v ->
+      checkAllRecordsCreated(allRecordsFutures, testContext, async));
+  }
+
+  @Test
+  public void canCreateMultipleDisabledUserConfigurationRecordsWithoutCode(
+    TestContext testContext) {
+
+    final Async async = testContext.async();
+
+    List<CompletableFuture<Response>> allRecordsFutures = new ArrayList<>();
+
+    final UUID userId = UUID.randomUUID();
+
+    final ConfigurationRecordBuilder baselineSetting = new ConfigurationRecordBuilder()
+      .withModuleName("CHECKOUT")
+      .withConfigName("main_settings")
+      .withNoCode()
+      .withValue("some value")
+      .forUser(userId);
+
+    JsonObject tenantConfigRecord = baselineSetting.create();
 
     allRecordsFutures.add(createConfigRecord(tenantConfigRecord));
 

--- a/mod-configuration-server/src/test/java/org/folio/rest/RestVerticleTest.java
+++ b/mod-configuration-server/src/test/java/org/folio/rest/RestVerticleTest.java
@@ -25,6 +25,7 @@ import org.folio.rest.security.AES;
 import org.folio.rest.tools.utils.NetworkUtils;
 import org.folio.support.CompletableFutureExtensions;
 import org.folio.support.ConfigurationRecordExamples;
+import org.folio.support.Response;
 import org.folio.support.builders.ConfigurationRecordBuilder;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -149,7 +150,7 @@ public class RestVerticleTest {
 
     postCompleted.thenAccept(response -> {
       try {
-        testContext.assertEquals(201, response.statusCode,
+        testContext.assertEquals(201, response.getStatusCode(),
           String.format("Unexpected status code: '%s': '%s'", response.getStatusCode(),
             response.getBody()));
 
@@ -206,7 +207,7 @@ public class RestVerticleTest {
 
     postCompleted.thenAccept(response -> {
       try {
-        testContext.assertEquals(201, response.statusCode,
+        testContext.assertEquals(201, response.getStatusCode(),
           String.format("Unexpected status code: '%s': '%s'", response.getStatusCode(),
             response.getBody()));
 
@@ -405,11 +406,11 @@ public class RestVerticleTest {
 
     final Response secondRecordResponse = secondRecordCreated.get(5, TimeUnit.SECONDS);
 
-    testContext.assertEquals(201, firstRecordResponse.statusCode,
+    testContext.assertEquals(201, firstRecordResponse.getStatusCode(),
       String.format("Unexpected status code: '%s': '%s'", firstRecordResponse.getStatusCode(),
         firstRecordResponse.getBody()));
 
-    testContext.assertEquals(422, secondRecordResponse.statusCode,
+    testContext.assertEquals(422, secondRecordResponse.getStatusCode(),
       String.format("Unexpected status code: '%s': '%s'", secondRecordResponse.getStatusCode(),
         secondRecordResponse.getBody()));
   }
@@ -445,11 +446,11 @@ public class RestVerticleTest {
 
     final Response secondRecordResponse = secondRecordCreated.get(5, TimeUnit.SECONDS);
 
-    testContext.assertEquals(201, firstRecordResponse.statusCode,
+    testContext.assertEquals(201, firstRecordResponse.getStatusCode(),
       String.format("Unexpected status code: '%s': '%s'", firstRecordResponse.getStatusCode(),
         firstRecordResponse.getBody()));
 
-    testContext.assertEquals(422, secondRecordResponse.statusCode,
+    testContext.assertEquals(422, secondRecordResponse.getStatusCode(),
       String.format("Unexpected status code: '%s': '%s'", secondRecordResponse.getStatusCode(),
         secondRecordResponse.getBody()));
   }
@@ -477,7 +478,7 @@ public class RestVerticleTest {
       get("http://localhost:" + port + "/configurations/entries?query=module==CHECKOUT"))
     .thenAccept(response -> {
       try {
-        testContext.assertEquals(200, response.statusCode,
+        testContext.assertEquals(200, response.getStatusCode(),
           String.format("Unexpected status code: '%s': '%s'", response.getStatusCode(),
             response.getBody()));
 
@@ -527,7 +528,7 @@ public class RestVerticleTest {
     get("http://localhost:" + port + "/configurations/entries" + "?query=" + encodedQuery)
       .thenAccept(response -> {
         try {
-          testContext.assertEquals(200, response.statusCode,
+          testContext.assertEquals(200, response.getStatusCode(),
             String.format("Unexpected status code: '%s': '%s'", response.getStatusCode(),
               response.getBody()));
 
@@ -910,24 +911,6 @@ public class RestVerticleTest {
     return getCompleted;
   }
 
-  private class Response {
-    private final Integer statusCode;
-    private final String body;
-
-    private Response(Integer statusCode, String body) {
-      this.statusCode = statusCode;
-      this.body = body;
-    }
-
-    Integer getStatusCode() {
-      return statusCode;
-    }
-
-    String getBody() {
-      return body;
-    }
-  }
-
   private void checkAllRecordsCreated(
     Iterable<CompletableFuture<Response>> allRecordsFutures,
     TestContext testContext,
@@ -937,7 +920,7 @@ public class RestVerticleTest {
       for (CompletableFuture<Response> future : allRecordsFutures) {
         Response response = future.get();
 
-        testContext.assertEquals(201, response.statusCode,
+        testContext.assertEquals(201, response.getStatusCode(),
           String.format("Unexpected status code: '%s': '%s'", response.getStatusCode(),
             response.getBody()));
       }

--- a/mod-configuration-server/src/test/java/org/folio/rest/RestVerticleTest.java
+++ b/mod-configuration-server/src/test/java/org/folio/rest/RestVerticleTest.java
@@ -349,6 +349,50 @@ public class RestVerticleTest {
   }
 
   @Test
+  public void canCreateTenantAndGroupConfigurationRecordsForSameModuleConfigNameAndNoCode(
+    TestContext testContext) {
+
+    final Async async = testContext.async();
+
+    List<CompletableFuture<Response>> allRecordsFutures = new ArrayList<>();
+
+    final ConfigurationRecordBuilder baselineSetting = new ConfigurationRecordBuilder()
+      .withModuleName("CHECKOUT")
+      .withConfigName("main_settings")
+      .withNoCode()
+      .withValue("some value");
+
+    JsonObject tenantConfigRecord = baselineSetting
+      .forNoUser()
+      .create();
+
+    allRecordsFutures.add(createConfigRecord(tenantConfigRecord));
+
+    final UUID firstUserId = UUID.randomUUID();
+
+    JsonObject firstUserConfigRecord = baselineSetting
+      .forUser(firstUserId)
+      .withValue("another value")
+      .create();
+
+    allRecordsFutures.add(createConfigRecord(firstUserConfigRecord));
+
+    final UUID secondUserId = UUID.randomUUID();
+
+    JsonObject secondUserConfigRecord = baselineSetting
+      .forUser(secondUserId)
+      .withValue("a different value")
+      .create();
+
+    allRecordsFutures.add(createConfigRecord(secondUserConfigRecord));
+
+    CompletableFuture<Void> allRecordsCompleted = allOf(allRecordsFutures);
+
+    allRecordsCompleted.thenAccept(v ->
+      checkAllRecordsCreated(allRecordsFutures, testContext, async));
+  }
+
+  @Test
   public void canCreateMultipleConfigurationRecordsWithDifferentConfigNameWithoutCode(
     TestContext testContext) {
 

--- a/mod-configuration-server/src/test/java/org/folio/rest/RestVerticleTest.java
+++ b/mod-configuration-server/src/test/java/org/folio/rest/RestVerticleTest.java
@@ -138,10 +138,10 @@ public class RestVerticleTest {
   public void canCreateConfigurationRecord(TestContext testContext) {
     final Async async = testContext.async();
 
-    JsonObject configRecord = new ConfigurationRecordBuilder().create(
+    JsonObject configRecord = new ConfigurationRecordBuilder(
       "audioAlertsEnabled",
       true,
-      "Whether audio alerts should be made during check out");
+      "Whether audio alerts should be made during check out").create();
 
     final CompletableFuture<Response> postCompleted = post(
       "http://localhost:" + port + "/configurations/entries",
@@ -233,19 +233,19 @@ public class RestVerticleTest {
 
     final ArrayList<CompletableFuture<Response>> allCreated = new ArrayList<>();
 
-    JsonObject firstConfigRecord = new ConfigurationRecordBuilder().create(
+    JsonObject firstConfigRecord = new ConfigurationRecordBuilder(
       "audioAlertsEnabled",
       true,
-      "Whether audio alerts should be made during check out");
+      "Whether audio alerts should be made during check out").create();
 
     allCreated.add(post(
       "http://localhost:" + port + "/configurations/entries",
       firstConfigRecord.encodePrettily()));
 
-    JsonObject secondConfigRecord = new ConfigurationRecordBuilder().create(
+    JsonObject secondConfigRecord = new ConfigurationRecordBuilder(
       "checkoutTimeoutDuration",
       3,
-      "How long the timeout for a check out session should be");
+      "How long the timeout for a check out session should be").create();
 
     allCreated.add(post(
       "http://localhost:" + port + "/configurations/entries",
@@ -282,10 +282,10 @@ public class RestVerticleTest {
 
     final Async async = testContext.async();
 
-    JsonObject firstConfigRecord = new ConfigurationRecordBuilder().create(
+    JsonObject firstConfigRecord = new ConfigurationRecordBuilder(
       "audioAlertsEnabled",
       true,
-      "Whether audio alerts should be made during check out");
+      "Whether audio alerts should be made during check out").create();
 
     final CompletableFuture<Response> firstRecordCreated = post(
       "http://localhost:" + port + "/configurations/entries",
@@ -294,10 +294,10 @@ public class RestVerticleTest {
     //Make sure the first record is created before the second
     firstRecordCreated.get(5, TimeUnit.SECONDS);
 
-    JsonObject secondConfigRecord = new ConfigurationRecordBuilder().create(
+    JsonObject secondConfigRecord = new ConfigurationRecordBuilder(
       "checkoutTimeoutDuration",
       3,
-      "How long the timeout for a check out session should be");
+      "How long the timeout for a check out session should be").create();
 
     final CompletableFuture<Response> secondRecordCreated = post(
       "http://localhost:" + port + "/configurations/entries",

--- a/mod-configuration-server/src/test/java/org/folio/rest/RestVerticleTest.java
+++ b/mod-configuration-server/src/test/java/org/folio/rest/RestVerticleTest.java
@@ -25,6 +25,7 @@ import org.folio.rest.security.AES;
 import org.folio.rest.tools.utils.NetworkUtils;
 import org.folio.support.CompletableFutureExtensions;
 import org.folio.support.ConfigurationRecordExamples;
+import org.folio.support.OkapiHttpClient;
 import org.folio.support.Response;
 import org.folio.support.builders.ConfigurationRecordBuilder;
 import org.junit.AfterClass;
@@ -54,9 +55,11 @@ public class RestVerticleTest {
   private static final String TOKEN = "eyJhbGciOiJIUzUxMiJ9eyJzdWIiOiJhZG1pbiIsInVzZXJfaWQiOiI3OWZmMmE4Yi1kOWMzLTViMzktYWQ0YS0wYTg0MDI1YWIwODUiLCJ0ZW5hbnQiOiJ0ZXN0X3RlbmFudCJ9BShwfHcNClt5ZXJ8ImQTMQtAM1sQEnhsfWNmXGsYVDpuaDN3RVQ9";
 
   private static Locale oldLocale;
-  private static Vertx vertx;
+  private static final Vertx vertx = Vertx.vertx();
   private static int port;
   private static TenantClient tClient = null;
+  private static final OkapiHttpClient okapiHttpClient = new OkapiHttpClient(
+    vertx, TENANT_ID, USER_ID, TOKEN);
 
   static {
     System.setProperty(LoggerFactory.LOGGER_DELEGATE_FACTORY_CLASS_NAME,
@@ -67,8 +70,6 @@ public class RestVerticleTest {
   public static void beforeAll(TestContext context) {
     oldLocale = Locale.getDefault();
     Locale.setDefault(Locale.US);
-
-    vertx = Vertx.vertx();
 
     try {
       AES.setSecretKey(SECRET_KEY);
@@ -144,7 +145,7 @@ public class RestVerticleTest {
 
     JsonObject configRecord = ConfigurationRecordExamples.audioAlertsExample().create();
 
-    final CompletableFuture<Response> postCompleted = post(
+    final CompletableFuture<Response> postCompleted = okapiHttpClient.post(
       "http://localhost:" + port + "/configurations/entries",
       configRecord.encodePrettily());
 
@@ -201,7 +202,7 @@ public class RestVerticleTest {
       .withValue("{ \"audioAlertsEnabled\": \"true\" }")
       .create();
 
-    final CompletableFuture<Response> postCompleted = post(
+    final CompletableFuture<Response> postCompleted = okapiHttpClient.post(
       "http://localhost:" + port + "/configurations/entries",
       configRecord.encodePrettily());
 
@@ -240,7 +241,7 @@ public class RestVerticleTest {
       .withValue("some value")
       .create();
 
-    final CompletableFuture<Response> firstRecordCompleted = post(
+    final CompletableFuture<Response> firstRecordCompleted = okapiHttpClient.post(
       "http://localhost:" + port + "/configurations/entries",
       firstConfigRecord.encodePrettily());
 
@@ -250,7 +251,7 @@ public class RestVerticleTest {
       .withValue("some other value")
       .create();
 
-    final CompletableFuture<Response> secondRecordCompleted = post(
+    final CompletableFuture<Response> secondRecordCompleted = okapiHttpClient.post(
       "http://localhost:" + port + "/configurations/entries",
       secondConfigRecord.encodePrettily());
 
@@ -275,7 +276,7 @@ public class RestVerticleTest {
       .withValue("some value")
       .create();
 
-    final CompletableFuture<Response> firstRecordCompleted = post(
+    final CompletableFuture<Response> firstRecordCompleted = okapiHttpClient.post(
       "http://localhost:" + port + "/configurations/entries",
       firstConfigRecord.encodePrettily());
 
@@ -285,7 +286,7 @@ public class RestVerticleTest {
       .withValue("some other value")
       .create();
 
-    final CompletableFuture<Response> secondRecordCompleted = post(
+    final CompletableFuture<Response> secondRecordCompleted = okapiHttpClient.post(
       "http://localhost:" + port + "/configurations/entries",
       secondConfigRecord.encodePrettily());
 
@@ -311,7 +312,7 @@ public class RestVerticleTest {
       .withValue("some value")
       .create();
 
-    final CompletableFuture<Response> firstRecordCompleted = post(
+    final CompletableFuture<Response> firstRecordCompleted = okapiHttpClient.post(
       "http://localhost:" + port + "/configurations/entries",
       firstConfigRecord.encodePrettily());
 
@@ -322,7 +323,7 @@ public class RestVerticleTest {
       .withValue("some other value")
       .create();
 
-    final CompletableFuture<Response> secondRecordCompleted = post(
+    final CompletableFuture<Response> secondRecordCompleted = okapiHttpClient.post(
       "http://localhost:" + port + "/configurations/entries",
       secondConfigRecord.encodePrettily());
 
@@ -348,7 +349,7 @@ public class RestVerticleTest {
       .withValue("some value")
       .create();
 
-    final CompletableFuture<Response> firstRecordCompleted = post(
+    final CompletableFuture<Response> firstRecordCompleted = okapiHttpClient.post(
       "http://localhost:" + port + "/configurations/entries",
       firstConfigRecord.encodePrettily());
 
@@ -359,7 +360,7 @@ public class RestVerticleTest {
       .withValue("some other value")
       .create();
 
-    final CompletableFuture<Response> secondRecordCompleted = post(
+    final CompletableFuture<Response> secondRecordCompleted = okapiHttpClient.post(
       "http://localhost:" + port + "/configurations/entries",
       secondConfigRecord.encodePrettily());
 
@@ -386,7 +387,7 @@ public class RestVerticleTest {
       .withValue("some value")
       .create();
 
-    final CompletableFuture<Response> firstRecordCreated = post(
+    final CompletableFuture<Response> firstRecordCreated = okapiHttpClient.post(
       "http://localhost:" + port + "/configurations/entries",
       firstConfigRecord.encodePrettily());
 
@@ -400,7 +401,7 @@ public class RestVerticleTest {
       .withValue("some other value")
       .create();
 
-    final CompletableFuture<Response> secondRecordCreated = post(
+    final CompletableFuture<Response> secondRecordCreated = okapiHttpClient.post(
       "http://localhost:" + port + "/configurations/entries",
       secondConfigRecord.encodePrettily());
 
@@ -427,7 +428,7 @@ public class RestVerticleTest {
       .withValue("some value")
       .create();
 
-    final CompletableFuture<Response> firstRecordCreated = post(
+    final CompletableFuture<Response> firstRecordCreated = okapiHttpClient.post(
       "http://localhost:" + port + "/configurations/entries",
       firstConfigRecord.encodePrettily());
 
@@ -440,7 +441,7 @@ public class RestVerticleTest {
       .withValue("some other value")
       .create();
 
-    final CompletableFuture<Response> secondRecordCreated = post(
+    final CompletableFuture<Response> secondRecordCreated = okapiHttpClient.post(
       "http://localhost:" + port + "/configurations/entries",
       secondConfigRecord.encodePrettily());
 
@@ -463,19 +464,19 @@ public class RestVerticleTest {
 
     JsonObject firstConfigRecord = ConfigurationRecordExamples.audioAlertsExample().create();
 
-    allCreated.add(post(
+    allCreated.add(okapiHttpClient.post(
       "http://localhost:" + port + "/configurations/entries",
       firstConfigRecord.encodePrettily()));
 
     JsonObject secondConfigRecord = ConfigurationRecordExamples.timeOutDurationExample().create();
 
-    allCreated.add(post(
+    allCreated.add(okapiHttpClient.post(
       "http://localhost:" + port + "/configurations/entries",
       secondConfigRecord.encodePrettily()));
 
     CompletableFutureExtensions.allOf(allCreated).thenComposeAsync(v ->
       //Must filter to only check out module entries due to default locale records
-      get("http://localhost:" + port + "/configurations/entries?query=module==CHECKOUT"))
+      okapiHttpClient.get("http://localhost:" + port + "/configurations/entries?query=module==CHECKOUT"))
     .thenAccept(response -> {
       try {
         testContext.assertEquals(200, response.getStatusCode(),
@@ -506,7 +507,7 @@ public class RestVerticleTest {
 
     JsonObject firstConfigRecord = ConfigurationRecordExamples.audioAlertsExample().create();
 
-    final CompletableFuture<Response> firstRecordCreated = post(
+    final CompletableFuture<Response> firstRecordCreated = okapiHttpClient.post(
       "http://localhost:" + port + "/configurations/entries",
       firstConfigRecord.encodePrettily());
 
@@ -515,7 +516,7 @@ public class RestVerticleTest {
 
     JsonObject secondConfigRecord = ConfigurationRecordExamples.timeOutDurationExample().create();
 
-    final CompletableFuture<Response> secondRecordCreated = post(
+    final CompletableFuture<Response> secondRecordCreated = okapiHttpClient.post(
       "http://localhost:" + port + "/configurations/entries",
       secondConfigRecord.encodePrettily());
 
@@ -525,7 +526,7 @@ public class RestVerticleTest {
       StandardCharsets.UTF_8.name());
 
     //Must filter to only check out module entries due to default locale records
-    get("http://localhost:" + port + "/configurations/entries" + "?query=" + encodedQuery)
+    okapiHttpClient.get("http://localhost:" + port + "/configurations/entries" + "?query=" + encodedQuery)
       .thenAccept(response -> {
         try {
           testContext.assertEquals(200, response.getStatusCode(),
@@ -700,7 +701,7 @@ public class RestVerticleTest {
           ? Integer.parseInt(urlInfo[4])
           : null;
 
-        final CompletableFuture<Response> responded = get(url);
+        final CompletableFuture<Response> responded = okapiHttpClient.get(url);
 
         try {
           Response response = responded.get(5, TimeUnit.SECONDS);
@@ -852,63 +853,6 @@ public class RestVerticleTest {
     });
 
     return allDeleted;
-  }
-
-  private CompletableFuture<Response> get(String url) {
-    HttpClient client = vertx.createHttpClient();
-
-    HttpClientRequest request = client.getAbs(url);
-
-    final CompletableFuture<Response> getCompleted = new CompletableFuture<>();
-
-    request.exceptionHandler(getCompleted::completeExceptionally);
-
-    request.handler(response ->
-      response.bodyHandler(buffer -> getCompleted.complete(
-        new Response(response.statusCode(),
-          buffer.getString(0, buffer.length())))));
-
-    request.putHeader("X-Okapi-Tenant", TENANT_ID);
-    request.putHeader("X-Okapi-Token", TOKEN);
-    request.putHeader("X-Okapi-User-Id", USER_ID);
-    request.putHeader("Accept", "application/json,text/plain");
-
-    request.end();
-
-    return getCompleted;
-  }
-
-  private CompletableFuture<Response> post(String url, String jsonContent) {
-    HttpClient client = vertx.createHttpClient();
-
-    HttpClientRequest request = client.postAbs(url);
-    Buffer requestBuffer = Buffer.buffer(jsonContent);
-
-    final CompletableFuture<Response> getCompleted = new CompletableFuture<>();
-
-    request.exceptionHandler(getCompleted::completeExceptionally);
-
-    request.handler(response ->
-      response.bodyHandler(responseBuffer -> {
-        final Response convertedResponse = new Response(
-          response.statusCode(),
-          responseBuffer.getString(0, responseBuffer.length()));
-
-        System.out.println(String.format("Received response: '%s':'%s'",
-          convertedResponse.getStatusCode(), convertedResponse.getBody()));
-
-        getCompleted.complete(convertedResponse);
-      }));
-
-    request.putHeader("X-Okapi-Tenant", TENANT_ID);
-    request.putHeader("X-Okapi-Token", TOKEN);
-    request.putHeader("X-Okapi-User-Id", USER_ID);
-    request.putHeader("Content-type", "application/json");
-    request.putHeader("Accept", "application/json,text/plain");
-
-    request.end(requestBuffer);
-
-    return getCompleted;
   }
 
   private void checkAllRecordsCreated(

--- a/mod-configuration-server/src/test/java/org/folio/rest/RestVerticleTest.java
+++ b/mod-configuration-server/src/test/java/org/folio/rest/RestVerticleTest.java
@@ -1057,6 +1057,48 @@ public class RestVerticleTest {
   }
 
   @Test
+  public void canCreateMultipleDisabledUserConfigurationRecordsWithCode(
+    TestContext testContext) {
+
+    final Async async = testContext.async();
+
+    List<CompletableFuture<Response>> allRecordsFutures = new ArrayList<>();
+
+    final UUID userId = UUID.randomUUID();
+
+    final ConfigurationRecordBuilder baselineSetting = new ConfigurationRecordBuilder()
+      .withModuleName("CHECKOUT")
+      .withConfigName("main_settings")
+      .withCode("example_setting")
+      .withValue("some value")
+      .forUser(userId);
+
+    JsonObject tenantConfigRecord = baselineSetting
+      .create();
+
+    allRecordsFutures.add(createConfigRecord(tenantConfigRecord));
+
+    JsonObject firstDisabledConfigRecord = baselineSetting
+      .withValue("another value")
+      .disabled()
+      .create();
+
+    allRecordsFutures.add(createConfigRecord(firstDisabledConfigRecord));
+
+    JsonObject secondDisabledConfigRecord = baselineSetting
+      .withValue("yet another value")
+      .disabled()
+      .create();
+
+    allRecordsFutures.add(createConfigRecord(secondDisabledConfigRecord));
+
+    CompletableFuture<Void> allRecordsCompleted = allOf(allRecordsFutures);
+
+    allRecordsCompleted.thenAccept(v ->
+      checkAllRecordsCreated(allRecordsFutures, testContext, async));
+  }
+
+  @Test
   public void canGetConfigurationRecords(TestContext testContext) {
     final Async async = testContext.async();
 

--- a/mod-configuration-server/src/test/java/org/folio/rest/RestVerticleTest.java
+++ b/mod-configuration-server/src/test/java/org/folio/rest/RestVerticleTest.java
@@ -11,6 +11,7 @@ import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.DecodeException;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
@@ -27,12 +28,15 @@ import org.folio.support.ConfigurationRecordExamples;
 import org.folio.support.OkapiHttpClient;
 import org.folio.support.Response;
 import org.folio.support.builders.ConfigurationRecordBuilder;
-import org.junit.*;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.lang.invoke.MethodHandles;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
@@ -48,6 +52,8 @@ import static org.folio.support.CompletableFutureExtensions.allOf;
  */
 @RunWith(VertxUnitRunner.class)
 public class RestVerticleTest {
+  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
   private static final String SECRET_KEY = "b2+S+X4F/NFys/0jMaEG1A";
   private static final String TENANT_ID = "harvard";
   private static final String USER_ID = "79ff2a8b-d9c3-5b39-ad4a-0a84025ab085";
@@ -95,7 +101,7 @@ public class RestVerticleTest {
             try {
               tClient.post(null, responseHandler ->
                 responseHandler.bodyHandler(body -> {
-                System.out.println(body.toString());
+                log.debug(body.toString());
                 async.complete();
               }));
             } catch (Exception e) {
@@ -117,7 +123,7 @@ public class RestVerticleTest {
   public static void afterAll(TestContext context) {
     Async async = context.async();
     tClient.delete(reply -> reply.bodyHandler(body -> {
-      System.out.println(body.toString());
+      log.debug(body.toString());
       vertx.close(context.asyncAssertSuccess(res-> {
         PostgresClient.stopEmbeddedPostgres();
         async.complete();
@@ -152,7 +158,7 @@ public class RestVerticleTest {
           String.format("Unexpected status code: '%s': '%s'", response.getStatusCode(),
             response.getBody()));
 
-        System.out.println(String.format("Create Response: '%s'", response.getBody()));
+        log.debug(String.format("Create Response: '%s'", response.getBody()));
 
         JsonObject createdRecord = new JsonObject(response.getBody());
 
@@ -207,7 +213,7 @@ public class RestVerticleTest {
           String.format("Unexpected status code: '%s': '%s'", response.getStatusCode(),
             response.getBody()));
 
-        System.out.println(String.format("Create Response: '%s'", response.getBody()));
+        log.debug(String.format("Create Response: '%s'", response.getBody()));
 
         JsonObject createdRecord = new JsonObject(response.getBody());
 
@@ -242,7 +248,7 @@ public class RestVerticleTest {
           String.format("Unexpected status code: '%s': '%s'", response.getStatusCode(),
             response.getBody()));
 
-        System.out.println(String.format("Create Response: '%s'", response.getBody()));
+        log.debug(String.format("Create Response: '%s'", response.getBody()));
 
         JsonObject createdRecord = new JsonObject(response.getBody());
 
@@ -283,7 +289,7 @@ public class RestVerticleTest {
           String.format("Unexpected status code: '%s': '%s'", response.getStatusCode(),
             response.getBody()));
 
-        System.out.println(String.format("Create Response: '%s'", response.getBody()));
+        log.debug(String.format("Create Response: '%s'", response.getBody()));
 
         JsonObject createdRecord = new JsonObject(response.getBody());
 
@@ -694,7 +700,7 @@ public class RestVerticleTest {
       String.format("Unexpected status code: '%s': '%s'", response.getStatusCode(),
         response.getBody()));
 
-    System.out.println(String.format("Create Response: '%s'", response.getBody()));
+    log.debug(String.format("Create Response: '%s'", response.getBody()));
 
     JsonObject createdRecord = new JsonObject(response.getBody());
 
@@ -727,7 +733,7 @@ public class RestVerticleTest {
       String.format("Unexpected status code: '%s': '%s'", response.getStatusCode(),
         response.getBody()));
 
-    System.out.println(String.format("Create Response: '%s'", response.getBody()));
+    log.debug(String.format("Create Response: '%s'", response.getBody()));
 
     JsonObject createdRecord = new JsonObject(response.getBody());
 
@@ -1243,9 +1249,9 @@ public class RestVerticleTest {
       "select * from harvard_mod_configuration.config_data where jsonb->>'config_name' = 'validation_rules'",  reply -> {
         if(reply.succeeded()){
           postgresClient.select("select * from harvard_mod_configuration.mytablecache", r3 -> {
-            System.out.println(r3.result().getResults().size());
+            log.debug(r3.result().getResults().size());
             postgresClient.removePersistentCacheResult("mytablecache", r4 -> {
-              System.out.println(r4.succeeded());
+              log.debug(r4.succeeded());
 
               /* this will probably cause a deadlock as the saveBatch runs within a transaction */
 
@@ -1255,7 +1261,7 @@ public class RestVerticleTest {
               try {
                 PostgresClient.getInstance(vertx, "harvard").saveBatch("config_data", a, reply1 -> {
                   if(reply1.succeeded()){
-                    System.out.println(new io.vertx.core.json.JsonArray( reply1.result().getResults() ).encodePrettily());
+                    log.debug(new io.vertx.core.json.JsonArray( reply1.result().getResults() ).encodePrettily());
                   }
                   async.complete();
                   });
@@ -1350,7 +1356,7 @@ public class RestVerticleTest {
 
       String updatedConf = new ObjectMapper().writeValueAsString(conf2);
 
-      System.out.println(updatedConf);
+      log.debug(updatedConf);
       mutateURLs("http://localhost:" + port + "/configurations/entries", context, HttpMethod.POST,
         updatedConf, "application/json", 201);
 
@@ -1436,12 +1442,12 @@ public class RestVerticleTest {
       context.fail(error.getMessage());
     }).handler(response -> {
       response.headers().forEach( header ->
-        System.out.println(header.getKey() + " " + header.getValue()));
+        log.debug(header.getKey() + " " + header.getValue()));
 
       int statusCode = response.statusCode();
       if(method == HttpMethod.POST && statusCode == 201){
         try {
-          System.out.println("Location - " + response.getHeader("Location"));
+          log.debug("Location - " + response.getHeader("Location"));
           Config conf =  new ObjectMapper().readValue(content, Config.class);
           conf.setDescription(conf.getDescription());
           mutateURLs("http://localhost:" + port + response.getHeader("Location"), context, HttpMethod.PUT,
@@ -1450,7 +1456,7 @@ public class RestVerticleTest {
           e.printStackTrace();
         }
       }
-      System.out.println("Status - " + statusCode + " at " + System.currentTimeMillis() + " for " + url);
+      log.debug("Status - " + statusCode + " at " + System.currentTimeMillis() + " for " + url);
       if(expectedStatusCode == statusCode){
         context.assertTrue(true);
       }
@@ -1464,7 +1470,7 @@ public class RestVerticleTest {
       if(!async.isCompleted()){
         async.complete();
       }
-      System.out.println("complete");
+      log.debug("complete");
     });
     request.setChunked(true);
     request.putHeader("X-Okapi-Request-Id", "999999999999");

--- a/mod-configuration-server/src/test/java/org/folio/rest/RestVerticleTest.java
+++ b/mod-configuration-server/src/test/java/org/folio/rest/RestVerticleTest.java
@@ -145,9 +145,7 @@ public class RestVerticleTest {
 
     JsonObject configRecord = ConfigurationRecordExamples.audioAlertsExample().create();
 
-    final CompletableFuture<Response> postCompleted = okapiHttpClient.post(
-      "http://localhost:" + port + "/configurations/entries",
-      configRecord.encodePrettily());
+    final CompletableFuture<Response> postCompleted = createConfigRecord(configRecord);
 
     postCompleted.thenAccept(response -> {
       try {
@@ -202,9 +200,7 @@ public class RestVerticleTest {
       .withValue("{ \"audioAlertsEnabled\": \"true\" }")
       .create();
 
-    final CompletableFuture<Response> postCompleted = okapiHttpClient.post(
-      "http://localhost:" + port + "/configurations/entries",
-      configRecord.encodePrettily());
+    final CompletableFuture<Response> postCompleted = createConfigRecord(configRecord);
 
     postCompleted.thenAccept(response -> {
       try {
@@ -239,9 +235,7 @@ public class RestVerticleTest {
       .forUser(userId)
       .create();
 
-    final CompletableFuture<Response> postCompleted = okapiHttpClient.post(
-      "http://localhost:" + port + "/configurations/entries",
-      configRecord.encodePrettily());
+    final CompletableFuture<Response> postCompleted = createConfigRecord(configRecord);
 
     postCompleted.thenAccept(response -> {
       try {
@@ -282,9 +276,7 @@ public class RestVerticleTest {
       .forUser(userId)
       .create();
 
-    final CompletableFuture<Response> postCompleted = okapiHttpClient.post(
-      "http://localhost:" + port + "/configurations/entries",
-      configRecord.encodePrettily());
+    final CompletableFuture<Response> postCompleted = createConfigRecord(configRecord);
 
     postCompleted.thenAccept(response -> {
       try {
@@ -323,9 +315,7 @@ public class RestVerticleTest {
       .withValue("some value")
       .create();
 
-    final CompletableFuture<Response> firstRecordCompleted = okapiHttpClient.post(
-      "http://localhost:" + port + "/configurations/entries",
-      firstConfigRecord.encodePrettily());
+    final CompletableFuture<Response> firstRecordCompleted = createConfigRecord(firstConfigRecord);
 
     JsonObject secondConfigRecord = new ConfigurationRecordBuilder()
       .withModuleName("CHECKOUT")
@@ -333,9 +323,7 @@ public class RestVerticleTest {
       .withValue("some other value")
       .create();
 
-    final CompletableFuture<Response> secondRecordCompleted = okapiHttpClient.post(
-      "http://localhost:" + port + "/configurations/entries",
-      secondConfigRecord.encodePrettily());
+    final CompletableFuture<Response> secondRecordCompleted = createConfigRecord(secondConfigRecord);
 
     List<CompletableFuture<Response>> allRecordsFutures = new ArrayList<>();
     allRecordsFutures.add(firstRecordCompleted);
@@ -358,9 +346,7 @@ public class RestVerticleTest {
       .withValue("some value")
       .create();
 
-    final CompletableFuture<Response> firstRecordCompleted = okapiHttpClient.post(
-      "http://localhost:" + port + "/configurations/entries",
-      firstConfigRecord.encodePrettily());
+    final CompletableFuture<Response> firstRecordCompleted = createConfigRecord(firstConfigRecord);
 
     JsonObject secondConfigRecord = new ConfigurationRecordBuilder()
       .withModuleName("RENEWAL")
@@ -368,9 +354,7 @@ public class RestVerticleTest {
       .withValue("some other value")
       .create();
 
-    final CompletableFuture<Response> secondRecordCompleted = okapiHttpClient.post(
-      "http://localhost:" + port + "/configurations/entries",
-      secondConfigRecord.encodePrettily());
+    final CompletableFuture<Response> secondRecordCompleted = createConfigRecord(secondConfigRecord);
 
     List<CompletableFuture<Response>> allRecordsFutures = new ArrayList<>();
     allRecordsFutures.add(firstRecordCompleted);
@@ -394,9 +378,7 @@ public class RestVerticleTest {
       .withValue("some value")
       .create();
 
-    final CompletableFuture<Response> firstRecordCompleted = okapiHttpClient.post(
-      "http://localhost:" + port + "/configurations/entries",
-      firstConfigRecord.encodePrettily());
+    final CompletableFuture<Response> firstRecordCompleted = createConfigRecord(firstConfigRecord);
 
     JsonObject secondConfigRecord = new ConfigurationRecordBuilder()
       .withModuleName("CHECKOUT")
@@ -405,9 +387,7 @@ public class RestVerticleTest {
       .withValue("some other value")
       .create();
 
-    final CompletableFuture<Response> secondRecordCompleted = okapiHttpClient.post(
-      "http://localhost:" + port + "/configurations/entries",
-      secondConfigRecord.encodePrettily());
+    final CompletableFuture<Response> secondRecordCompleted = createConfigRecord(secondConfigRecord);
 
     List<CompletableFuture<Response>> allRecordsFutures = new ArrayList<>();
     allRecordsFutures.add(firstRecordCompleted);
@@ -431,9 +411,7 @@ public class RestVerticleTest {
       .withValue("some value")
       .create();
 
-    final CompletableFuture<Response> firstRecordCompleted = okapiHttpClient.post(
-      "http://localhost:" + port + "/configurations/entries",
-      firstConfigRecord.encodePrettily());
+    final CompletableFuture<Response> firstRecordCompleted = createConfigRecord(firstConfigRecord);
 
     JsonObject secondConfigRecord = new ConfigurationRecordBuilder()
       .withModuleName("RENEWAL")
@@ -442,9 +420,7 @@ public class RestVerticleTest {
       .withValue("some other value")
       .create();
 
-    final CompletableFuture<Response> secondRecordCompleted = okapiHttpClient.post(
-      "http://localhost:" + port + "/configurations/entries",
-      secondConfigRecord.encodePrettily());
+    final CompletableFuture<Response> secondRecordCompleted = createConfigRecord(secondConfigRecord);
 
     List<CompletableFuture<Response>> allRecordsFutures = new ArrayList<>();
     allRecordsFutures.add(firstRecordCompleted);
@@ -469,9 +445,7 @@ public class RestVerticleTest {
       .withValue("some value")
       .create();
 
-    final CompletableFuture<Response> firstRecordCreated = okapiHttpClient.post(
-      "http://localhost:" + port + "/configurations/entries",
-      firstConfigRecord.encodePrettily());
+    final CompletableFuture<Response> firstRecordCreated = createConfigRecord(firstConfigRecord);
 
     //Make sure the first record is created before the second
     final Response firstRecordResponse = firstRecordCreated.get(5, TimeUnit.SECONDS);
@@ -483,9 +457,7 @@ public class RestVerticleTest {
       .withValue("some other value")
       .create();
 
-    final CompletableFuture<Response> secondRecordCreated = okapiHttpClient.post(
-      "http://localhost:" + port + "/configurations/entries",
-      secondConfigRecord.encodePrettily());
+    final CompletableFuture<Response> secondRecordCreated = createConfigRecord(secondConfigRecord);
 
     final Response secondRecordResponse = secondRecordCreated.get(5, TimeUnit.SECONDS);
 
@@ -510,9 +482,7 @@ public class RestVerticleTest {
       .withValue("some value")
       .create();
 
-    final CompletableFuture<Response> firstRecordCreated = okapiHttpClient.post(
-      "http://localhost:" + port + "/configurations/entries",
-      firstConfigRecord.encodePrettily());
+    final CompletableFuture<Response> firstRecordCreated = createConfigRecord(firstConfigRecord);
 
     //Make sure the first record is created before the second
     final Response firstRecordResponse = firstRecordCreated.get(5, TimeUnit.SECONDS);
@@ -523,9 +493,7 @@ public class RestVerticleTest {
       .withValue("some other value")
       .create();
 
-    final CompletableFuture<Response> secondRecordCreated = okapiHttpClient.post(
-      "http://localhost:" + port + "/configurations/entries",
-      secondConfigRecord.encodePrettily());
+    final CompletableFuture<Response> secondRecordCreated = createConfigRecord(secondConfigRecord);
 
     final Response secondRecordResponse = secondRecordCreated.get(5, TimeUnit.SECONDS);
 
@@ -546,15 +514,11 @@ public class RestVerticleTest {
 
     JsonObject firstConfigRecord = ConfigurationRecordExamples.audioAlertsExample().create();
 
-    allCreated.add(okapiHttpClient.post(
-      "http://localhost:" + port + "/configurations/entries",
-      firstConfigRecord.encodePrettily()));
+    allCreated.add(createConfigRecord(firstConfigRecord));
 
     JsonObject secondConfigRecord = ConfigurationRecordExamples.timeOutDurationExample().create();
 
-    allCreated.add(okapiHttpClient.post(
-      "http://localhost:" + port + "/configurations/entries",
-      secondConfigRecord.encodePrettily()));
+    allCreated.add(createConfigRecord(secondConfigRecord));
 
     CompletableFutureExtensions.allOf(allCreated).thenComposeAsync(v ->
       //Must filter to only check out module entries due to default locale records
@@ -589,18 +553,14 @@ public class RestVerticleTest {
 
     JsonObject firstConfigRecord = ConfigurationRecordExamples.audioAlertsExample().create();
 
-    final CompletableFuture<Response> firstRecordCreated = okapiHttpClient.post(
-      "http://localhost:" + port + "/configurations/entries",
-      firstConfigRecord.encodePrettily());
+    final CompletableFuture<Response> firstRecordCreated = createConfigRecord(firstConfigRecord);
 
     //Make sure the first record is created before the second
     firstRecordCreated.get(5, TimeUnit.SECONDS);
 
     JsonObject secondConfigRecord = ConfigurationRecordExamples.timeOutDurationExample().create();
 
-    final CompletableFuture<Response> secondRecordCreated = okapiHttpClient.post(
-      "http://localhost:" + port + "/configurations/entries",
-      secondConfigRecord.encodePrettily());
+    final CompletableFuture<Response> secondRecordCreated = createConfigRecord(secondConfigRecord);
 
     secondRecordCreated.get(5, TimeUnit.SECONDS);
 
@@ -957,5 +917,11 @@ public class RestVerticleTest {
     finally {
       async.complete();
     }
+  }
+
+  private CompletableFuture<Response> createConfigRecord(JsonObject record) {
+    return okapiHttpClient.post(
+      "http://localhost:" + port + "/configurations/entries",
+      record.encodePrettily());
   }
 }

--- a/mod-configuration-server/src/test/java/org/folio/rest/RestVerticleTest.java
+++ b/mod-configuration-server/src/test/java/org/folio/rest/RestVerticleTest.java
@@ -23,6 +23,7 @@ import org.folio.rest.jaxrs.model.TenantAttributes;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.security.AES;
 import org.folio.rest.tools.utils.NetworkUtils;
+import org.folio.support.CompletableFutureExtensions;
 import org.folio.support.ConfigurationRecordExamples;
 import org.folio.support.builders.ConfigurationRecordBuilder;
 import org.junit.AfterClass;
@@ -256,7 +257,7 @@ public class RestVerticleTest {
     allRecordsFutures.add(firstRecordCompleted);
     allRecordsFutures.add(secondRecordCompleted);
 
-    CompletableFuture<Void> allRecordsCompleted = allOf(allRecordsFutures);
+    CompletableFuture<Void> allRecordsCompleted = CompletableFutureExtensions.allOf(allRecordsFutures);
 
     allRecordsCompleted.thenAccept(v ->
       checkAllRecordsCreated(allRecordsFutures, testContext, async));
@@ -291,7 +292,7 @@ public class RestVerticleTest {
     allRecordsFutures.add(firstRecordCompleted);
     allRecordsFutures.add(secondRecordCompleted);
 
-    CompletableFuture<Void> allRecordsCompleted = allOf(allRecordsFutures);
+    CompletableFuture<Void> allRecordsCompleted = CompletableFutureExtensions.allOf(allRecordsFutures);
 
     allRecordsCompleted.thenAccept(v ->
       checkAllRecordsCreated(allRecordsFutures, testContext, async));
@@ -328,7 +329,7 @@ public class RestVerticleTest {
     allRecordsFutures.add(firstRecordCompleted);
     allRecordsFutures.add(secondRecordCompleted);
 
-    CompletableFuture<Void> allRecordsCompleted = allOf(allRecordsFutures);
+    CompletableFuture<Void> allRecordsCompleted = CompletableFutureExtensions.allOf(allRecordsFutures);
 
     allRecordsCompleted.thenAccept(v ->
       checkAllRecordsCreated(allRecordsFutures, testContext, async));
@@ -365,7 +366,7 @@ public class RestVerticleTest {
     allRecordsFutures.add(firstRecordCompleted);
     allRecordsFutures.add(secondRecordCompleted);
 
-    CompletableFuture<Void> allRecordsCompleted = allOf(allRecordsFutures);
+    CompletableFuture<Void> allRecordsCompleted = CompletableFutureExtensions.allOf(allRecordsFutures);
 
     allRecordsCompleted.thenAccept(v ->
       checkAllRecordsCreated(allRecordsFutures, testContext, async));
@@ -471,7 +472,7 @@ public class RestVerticleTest {
       "http://localhost:" + port + "/configurations/entries",
       secondConfigRecord.encodePrettily()));
 
-    allOf(allCreated).thenComposeAsync(v ->
+    CompletableFutureExtensions.allOf(allCreated).thenComposeAsync(v ->
       //Must filter to only check out module entries due to default locale records
       get("http://localhost:" + port + "/configurations/entries?query=module==CHECKOUT"))
     .thenAccept(response -> {
@@ -927,13 +928,11 @@ public class RestVerticleTest {
     }
   }
 
-  public static <T> CompletableFuture<Void> allOf(
-    List<CompletableFuture<T>> allFutures) {
+  private void checkAllRecordsCreated(
+    Iterable<CompletableFuture<Response>> allRecordsFutures,
+    TestContext testContext,
+    Async async) {
 
-    return CompletableFuture.allOf(allFutures.toArray(new CompletableFuture<?>[] { }));
-  }
-
-  private void checkAllRecordsCreated(Iterable<CompletableFuture<Response>> allRecordsFutures, TestContext testContext, Async async) {
     try {
       for (CompletableFuture<Response> future : allRecordsFutures) {
         Response response = future.get();

--- a/mod-configuration-server/src/test/java/org/folio/rest/RestVerticleTest.java
+++ b/mod-configuration-server/src/test/java/org/folio/rest/RestVerticleTest.java
@@ -333,6 +333,43 @@ public class RestVerticleTest {
   }
 
   @Test
+  public void canCreateMultipleConfigurationRecordsWithDifferentModuleName(
+    TestContext testContext) {
+    final Async async = testContext.async();
+
+    JsonObject firstConfigRecord = new ConfigurationRecordBuilder()
+      .withModuleName("CHECKOUT")
+      .withConfigName("main_settings")
+      .withCode("first_setting")
+      .withValue("some value")
+      .create();
+
+    final CompletableFuture<Response> firstRecordCompleted = post(
+      "http://localhost:" + port + "/configurations/entries",
+      firstConfigRecord.encodePrettily());
+
+    JsonObject secondConfigRecord = new ConfigurationRecordBuilder()
+      .withModuleName("RENEWAL")
+      .withConfigName("main_settings")
+      .withCode("first_setting")
+      .withValue("some other value")
+      .create();
+
+    final CompletableFuture<Response> secondRecordCompleted = post(
+      "http://localhost:" + port + "/configurations/entries",
+      secondConfigRecord.encodePrettily());
+
+    List<CompletableFuture<Response>> allRecordsFutures = new ArrayList<>();
+    allRecordsFutures.add(firstRecordCompleted);
+    allRecordsFutures.add(secondRecordCompleted);
+
+    CompletableFuture<Void> allRecordsCompleted = allOf(allRecordsFutures);
+
+    allRecordsCompleted.thenAccept(v ->
+      checkAllRecordsCreated(allRecordsFutures, testContext, async));
+  }
+
+  @Test
   public void canGetConfigurationRecords(TestContext testContext) {
     final Async async = testContext.async();
 

--- a/mod-configuration-server/src/test/java/org/folio/rest/RestVerticleTest.java
+++ b/mod-configuration-server/src/test/java/org/folio/rest/RestVerticleTest.java
@@ -138,10 +138,11 @@ public class RestVerticleTest {
   public void canCreateConfigurationRecord(TestContext testContext) {
     final Async async = testContext.async();
 
-    JsonObject configRecord = new ConfigurationRecordBuilder(
-      "audioAlertsEnabled",
-      true,
-      "Whether audio alerts should be made during check out").create();
+    JsonObject configRecord = new ConfigurationRecordBuilder()
+      .withCode("audioAlertsEnabled")
+      .withValue(true)
+      .withDescription("Whether audio alerts should be made during check out")
+      .create();
 
     final CompletableFuture<Response> postCompleted = post(
       "http://localhost:" + port + "/configurations/entries",
@@ -233,19 +234,21 @@ public class RestVerticleTest {
 
     final ArrayList<CompletableFuture<Response>> allCreated = new ArrayList<>();
 
-    JsonObject firstConfigRecord = new ConfigurationRecordBuilder(
-      "audioAlertsEnabled",
-      true,
-      "Whether audio alerts should be made during check out").create();
+    JsonObject firstConfigRecord = new ConfigurationRecordBuilder()
+      .withCode("audioAlertsEnabled")
+      .withValue(true)
+      .withDescription("Whether audio alerts should be made during check out")
+      .create();
 
     allCreated.add(post(
       "http://localhost:" + port + "/configurations/entries",
       firstConfigRecord.encodePrettily()));
 
-    JsonObject secondConfigRecord = new ConfigurationRecordBuilder(
-      "checkoutTimeoutDuration",
-      3,
-      "How long the timeout for a check out session should be").create();
+    JsonObject secondConfigRecord = new ConfigurationRecordBuilder()
+      .withCode("checkoutTimeoutDuration")
+      .withValue(3)
+      .withDescription("How long the timeout for a check out session should be")
+      .create();
 
     allCreated.add(post(
       "http://localhost:" + port + "/configurations/entries",
@@ -282,10 +285,11 @@ public class RestVerticleTest {
 
     final Async async = testContext.async();
 
-    JsonObject firstConfigRecord = new ConfigurationRecordBuilder(
-      "audioAlertsEnabled",
-      true,
-      "Whether audio alerts should be made during check out").create();
+    JsonObject firstConfigRecord = new ConfigurationRecordBuilder()
+      .withCode("audioAlertsEnabled")
+      .withValue(true)
+      .withDescription("Whether audio alerts should be made during check out")
+      .create();
 
     final CompletableFuture<Response> firstRecordCreated = post(
       "http://localhost:" + port + "/configurations/entries",
@@ -294,10 +298,11 @@ public class RestVerticleTest {
     //Make sure the first record is created before the second
     firstRecordCreated.get(5, TimeUnit.SECONDS);
 
-    JsonObject secondConfigRecord = new ConfigurationRecordBuilder(
-      "checkoutTimeoutDuration",
-      3,
-      "How long the timeout for a check out session should be").create();
+    JsonObject secondConfigRecord = new ConfigurationRecordBuilder()
+      .withCode("checkoutTimeoutDuration")
+      .withValue(3)
+      .withDescription("How long the timeout for a check out session should be")
+      .create();
 
     final CompletableFuture<Response> secondRecordCreated = post(
       "http://localhost:" + port + "/configurations/entries",

--- a/mod-configuration-server/src/test/java/org/folio/rest/RestVerticleTest.java
+++ b/mod-configuration-server/src/test/java/org/folio/rest/RestVerticleTest.java
@@ -979,6 +979,45 @@ public class RestVerticleTest {
   }
 
   @Test
+  public void canCreateMultipleDisabledTenantConfigurationRecordsWithCode(
+    TestContext testContext) {
+
+    final Async async = testContext.async();
+
+    List<CompletableFuture<Response>> allRecordsFutures = new ArrayList<>();
+
+    final ConfigurationRecordBuilder baselineSetting = new ConfigurationRecordBuilder()
+      .withModuleName("CHECKOUT")
+      .withConfigName("main_settings")
+      .withCode("example_setting")
+      .withValue("some value");
+
+    JsonObject tenantConfigRecord = baselineSetting
+      .create();
+
+    allRecordsFutures.add(createConfigRecord(tenantConfigRecord));
+
+    JsonObject firstDisabledConfigRecord = baselineSetting
+      .withValue("another value")
+      .disabled()
+      .create();
+
+    allRecordsFutures.add(createConfigRecord(firstDisabledConfigRecord));
+
+    JsonObject secondDisabledConfigRecord = baselineSetting
+      .withValue("yet another value")
+      .disabled()
+      .create();
+
+    allRecordsFutures.add(createConfigRecord(secondDisabledConfigRecord));
+
+    CompletableFuture<Void> allRecordsCompleted = allOf(allRecordsFutures);
+
+    allRecordsCompleted.thenAccept(v ->
+      checkAllRecordsCreated(allRecordsFutures, testContext, async));
+  }
+
+  @Test
   public void canGetConfigurationRecords(TestContext testContext) {
     final Async async = testContext.async();
 

--- a/mod-configuration-server/src/test/java/org/folio/support/CompletableFutureExtensions.java
+++ b/mod-configuration-server/src/test/java/org/folio/support/CompletableFutureExtensions.java
@@ -1,0 +1,14 @@
+package org.folio.support;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+public class CompletableFutureExtensions {
+  private CompletableFutureExtensions() { }
+
+  public static <T> CompletableFuture<Void> allOf(
+    List<CompletableFuture<T>> allFutures) {
+
+    return CompletableFuture.allOf(allFutures.toArray(new CompletableFuture<?>[] { }));
+  }
+}

--- a/mod-configuration-server/src/test/java/org/folio/support/ConfigurationRecordExamples.java
+++ b/mod-configuration-server/src/test/java/org/folio/support/ConfigurationRecordExamples.java
@@ -1,0 +1,25 @@
+package org.folio.support;
+
+import org.folio.support.builders.ConfigurationRecordBuilder;
+
+public class ConfigurationRecordExamples {
+  private ConfigurationRecordExamples() { }
+
+  public static ConfigurationRecordBuilder timeOutDurationExample() {
+    return new ConfigurationRecordBuilder()
+      .withModuleName("CHECKOUT")
+      .withConfigName("other_settings")
+      .withCode("checkoutTimeoutDuration")
+      .withValue(3)
+      .withDescription("How long the timeout for a check out session should be");
+  }
+
+  public static ConfigurationRecordBuilder audioAlertsExample() {
+    return new ConfigurationRecordBuilder()
+      .withModuleName("CHECKOUT")
+      .withConfigName("other_settings")
+      .withCode("audioAlertsEnabled")
+      .withValue(true)
+      .withDescription("Whether audio alerts should be made during check out");
+  }
+}

--- a/mod-configuration-server/src/test/java/org/folio/support/OkapiHttpClient.java
+++ b/mod-configuration-server/src/test/java/org/folio/support/OkapiHttpClient.java
@@ -1,0 +1,79 @@
+package org.folio.support;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.http.HttpClientRequest;
+
+import java.util.concurrent.CompletableFuture;
+
+public class OkapiHttpClient {
+  private final Vertx vertx;
+  private final String tenantId;
+  private final String userId;
+  private final String token;
+
+  public OkapiHttpClient(Vertx vertx, String tenantId, String userId, String token) {
+    this.vertx = vertx;
+    this.tenantId = tenantId;
+    this.userId = userId;
+    this.token = token;
+  }
+
+  public CompletableFuture<Response> post(String url, String jsonContent) {
+    HttpClient client = vertx.createHttpClient();
+
+    HttpClientRequest request = client.postAbs(url);
+    Buffer requestBuffer = Buffer.buffer(jsonContent);
+
+    final CompletableFuture<Response> getCompleted = new CompletableFuture<>();
+
+    request.exceptionHandler(getCompleted::completeExceptionally);
+
+    request.handler(response ->
+      response.bodyHandler(responseBuffer -> {
+        final Response convertedResponse = new Response(
+          response.statusCode(),
+          responseBuffer.getString(0, responseBuffer.length()));
+
+        System.out.println(String.format("Received response: '%s':'%s'",
+          convertedResponse.getStatusCode(), convertedResponse.getBody()));
+
+        getCompleted.complete(convertedResponse);
+      }));
+
+    request.putHeader("X-Okapi-Tenant", tenantId);
+    request.putHeader("X-Okapi-Token", token);
+    request.putHeader("X-Okapi-User-Id", userId);
+    request.putHeader("Content-type", "application/json");
+    request.putHeader("Accept", "application/json, text/plain");
+
+    request.end(requestBuffer);
+
+    return getCompleted;
+  }
+
+  public CompletableFuture<Response> get(String url) {
+    HttpClient client = vertx.createHttpClient();
+
+    HttpClientRequest request = client.getAbs(url);
+
+    final CompletableFuture<Response> getCompleted = new CompletableFuture<>();
+
+    request.exceptionHandler(getCompleted::completeExceptionally);
+
+    request.handler(response ->
+      response.bodyHandler(buffer -> getCompleted.complete(
+        new Response(response.statusCode(),
+          buffer.getString(0, buffer.length())))));
+
+    request.putHeader("X-Okapi-Tenant", tenantId);
+    request.putHeader("X-Okapi-Token", token);
+    request.putHeader("X-Okapi-User-Id", userId);
+    request.putHeader("Accept", "application/json, text/plain");
+
+    request.end();
+
+    return getCompleted;
+  }
+}

--- a/mod-configuration-server/src/test/java/org/folio/support/OkapiHttpClient.java
+++ b/mod-configuration-server/src/test/java/org/folio/support/OkapiHttpClient.java
@@ -26,9 +26,45 @@ public class OkapiHttpClient {
     HttpClientRequest request = client.postAbs(url);
     Buffer requestBuffer = Buffer.buffer(jsonContent);
 
+    final CompletableFuture<Response> postCompleted = new CompletableFuture<>();
+
+    request.exceptionHandler(postCompleted::completeExceptionally);
+
+    request.setTimeout(5000);
+
+    request.handler(response ->
+      response.bodyHandler(responseBuffer -> {
+        final Response convertedResponse = new Response(
+          response.statusCode(),
+          responseBuffer.getString(0, responseBuffer.length()));
+
+        System.out.println(String.format("Received response: '%s':'%s'",
+          convertedResponse.getStatusCode(), convertedResponse.getBody()));
+
+        postCompleted.complete(convertedResponse);
+      }));
+
+    request.putHeader("X-Okapi-Tenant", tenantId);
+    request.putHeader("X-Okapi-Token", token);
+    request.putHeader("X-Okapi-User-Id", userId);
+    request.putHeader("Content-type", "application/json");
+    request.putHeader("Accept", "application/json, text/plain");
+
+    request.end(requestBuffer);
+
+    return postCompleted;
+  }
+
+  public CompletableFuture<Response> get(String url) {
+    HttpClient client = vertx.createHttpClient();
+
+    HttpClientRequest request = client.getAbs(url);
+
     final CompletableFuture<Response> getCompleted = new CompletableFuture<>();
 
     request.exceptionHandler(getCompleted::completeExceptionally);
+
+    request.setTimeout(5000);
 
     request.handler(response ->
       response.bodyHandler(responseBuffer -> {
@@ -45,35 +81,45 @@ public class OkapiHttpClient {
     request.putHeader("X-Okapi-Tenant", tenantId);
     request.putHeader("X-Okapi-Token", token);
     request.putHeader("X-Okapi-User-Id", userId);
-    request.putHeader("Content-type", "application/json");
-    request.putHeader("Accept", "application/json, text/plain");
-
-    request.end(requestBuffer);
-
-    return getCompleted;
-  }
-
-  public CompletableFuture<Response> get(String url) {
-    HttpClient client = vertx.createHttpClient();
-
-    HttpClientRequest request = client.getAbs(url);
-
-    final CompletableFuture<Response> getCompleted = new CompletableFuture<>();
-
-    request.exceptionHandler(getCompleted::completeExceptionally);
-
-    request.handler(response ->
-      response.bodyHandler(buffer -> getCompleted.complete(
-        new Response(response.statusCode(),
-          buffer.getString(0, buffer.length())))));
-
-    request.putHeader("X-Okapi-Tenant", tenantId);
-    request.putHeader("X-Okapi-Token", token);
-    request.putHeader("X-Okapi-User-Id", userId);
     request.putHeader("Accept", "application/json, text/plain");
 
     request.end();
 
     return getCompleted;
+  }
+
+  public CompletableFuture<Response> put(String url, String jsonContent) {
+    HttpClient client = vertx.createHttpClient();
+
+    HttpClientRequest request = client.putAbs(url);
+    Buffer requestBuffer = Buffer.buffer(jsonContent);
+
+    final CompletableFuture<Response> putCompleted = new CompletableFuture<>();
+
+    request.exceptionHandler(putCompleted::completeExceptionally);
+
+    request.setTimeout(5000);
+
+    request.handler(response ->
+      response.bodyHandler(responseBuffer -> {
+        final Response convertedResponse = new Response(
+          response.statusCode(),
+          responseBuffer.getString(0, responseBuffer.length()));
+
+        System.out.println(String.format("Received response: '%s':'%s'",
+          convertedResponse.getStatusCode(), convertedResponse.getBody()));
+
+        putCompleted.complete(convertedResponse);
+      }));
+
+    request.putHeader("X-Okapi-Tenant", tenantId);
+    request.putHeader("X-Okapi-Token", token);
+    request.putHeader("X-Okapi-User-Id", userId);
+    request.putHeader("Content-type", "application/json");
+    request.putHeader("Accept", "application/json, text/plain");
+
+    request.end(requestBuffer);
+
+    return putCompleted;
   }
 }

--- a/mod-configuration-server/src/test/java/org/folio/support/Response.java
+++ b/mod-configuration-server/src/test/java/org/folio/support/Response.java
@@ -1,0 +1,19 @@
+package org.folio.support;
+
+public class Response {
+  private final Integer statusCode;
+  private final String body;
+
+  public Response(Integer statusCode, String body) {
+    this.statusCode = statusCode;
+    this.body = body;
+  }
+
+  public Integer getStatusCode() {
+    return statusCode;
+  }
+
+  public String getBody() {
+    return body;
+  }
+}

--- a/mod-configuration-server/src/test/java/org/folio/support/Response.java
+++ b/mod-configuration-server/src/test/java/org/folio/support/Response.java
@@ -1,10 +1,12 @@
 package org.folio.support;
 
+import io.vertx.core.json.JsonObject;
+
 public class Response {
   private final Integer statusCode;
   private final String body;
 
-  public Response(Integer statusCode, String body) {
+  Response(Integer statusCode, String body) {
     this.statusCode = statusCode;
     this.body = body;
   }
@@ -15,5 +17,9 @@ public class Response {
 
   public String getBody() {
     return body;
+  }
+
+  public JsonObject getBodyAsJson() {
+    return new JsonObject(getBody());
   }
 }

--- a/mod-configuration-server/src/test/java/org/folio/support/builders/ConfigurationRecordBuilder.java
+++ b/mod-configuration-server/src/test/java/org/folio/support/builders/ConfigurationRecordBuilder.java
@@ -4,17 +4,19 @@ import io.vertx.core.json.JsonObject;
 
 public class ConfigurationRecordBuilder extends JsonBuilder {
 
-  private String moduleName;
-  private String code;
-  private Object value;
-  private String description;
+  private final String moduleName;
+  private final String configName;
+  private final String code;
+  private final Object value;
+  private final String description;
 
   public ConfigurationRecordBuilder() {
-    this(null, null, null, null);
+    this(null, "other_settings", null, null, null);
   }
 
   private ConfigurationRecordBuilder(
     String moduleName,
+    String configName,
     String code,
     Object value,
     String description) {
@@ -23,13 +25,14 @@ public class ConfigurationRecordBuilder extends JsonBuilder {
     this.code = code;
     this.value = value;
     this.description = description;
+    this.configName = configName;
   }
 
   public JsonObject create() {
     final JsonObject configurationRecord = new JsonObject();
 
     put(configurationRecord, "module", this.moduleName);
-    put(configurationRecord, "configName", "other_settings");
+    put(configurationRecord, "configName", configName);
     put(configurationRecord, "description", this.description);
     put(configurationRecord, "code", this.code);
     put(configurationRecord, "value", this.value);
@@ -40,32 +43,50 @@ public class ConfigurationRecordBuilder extends JsonBuilder {
   public ConfigurationRecordBuilder withModuleName(String moduleName) {
     return new ConfigurationRecordBuilder(
       moduleName,
+      this.configName,
       this.code,
       this.value,
-      this.description);
+      this.description
+    );
+  }
+
+  public ConfigurationRecordBuilder withConfigName(String configName) {
+    return new ConfigurationRecordBuilder(
+      this.moduleName,
+      configName,
+      this.code,
+      this.value,
+      this.description
+    );
   }
 
   public ConfigurationRecordBuilder withCode(String code) {
     return new ConfigurationRecordBuilder(
       this.moduleName,
+      this.configName,
       code,
       this.value,
-      this.description);
+      this.description
+    );
   }
 
   public ConfigurationRecordBuilder withValue(Object value) {
     return new ConfigurationRecordBuilder(
       this.moduleName,
+      this.configName,
       this.code,
       value,
-      this.description);
+      this.description
+    );
   }
 
   public ConfigurationRecordBuilder withDescription(String description) {
     return new ConfigurationRecordBuilder(
       this.moduleName,
+      this.configName,
       this.code,
       this.value,
-      description);
+      description
+    );
   }
 }

--- a/mod-configuration-server/src/test/java/org/folio/support/builders/ConfigurationRecordBuilder.java
+++ b/mod-configuration-server/src/test/java/org/folio/support/builders/ConfigurationRecordBuilder.java
@@ -8,7 +8,11 @@ public class ConfigurationRecordBuilder extends JsonBuilder {
   private Object value;
   private String description;
 
-  public ConfigurationRecordBuilder(
+  public ConfigurationRecordBuilder() {
+    this(null, null, null);
+  }
+
+  private ConfigurationRecordBuilder(
     String code,
     Object value,
     String description) {
@@ -28,5 +32,26 @@ public class ConfigurationRecordBuilder extends JsonBuilder {
     put(configurationRecord, "value", this.value);
 
     return configurationRecord;
+  }
+
+  public ConfigurationRecordBuilder withCode(String code) {
+    return new ConfigurationRecordBuilder(
+      code,
+      this.value,
+      this.description);
+  }
+
+  public ConfigurationRecordBuilder withValue(Object value) {
+    return new ConfigurationRecordBuilder(
+      this.code,
+      value,
+      this.description);
+  }
+
+  public ConfigurationRecordBuilder withDescription(String description) {
+    return new ConfigurationRecordBuilder(
+      this.code,
+      this.value,
+      description);
   }
 }

--- a/mod-configuration-server/src/test/java/org/folio/support/builders/ConfigurationRecordBuilder.java
+++ b/mod-configuration-server/src/test/java/org/folio/support/builders/ConfigurationRecordBuilder.java
@@ -2,17 +2,20 @@ package org.folio.support.builders;
 
 import io.vertx.core.json.JsonObject;
 
-public class ConfigurationRecordBuilder {
+public class ConfigurationRecordBuilder extends JsonBuilder {
   public JsonObject create(
     String code,
     Object value,
     String description) {
 
-    return new JsonObject()
-      .put("module", "CHECKOUT")
-      .put("configName", "other_settings")
-      .put("description", description)
-      .put("code", code)
-      .put("value", value);
+    final JsonObject configurationRecord = new JsonObject();
+
+    put(configurationRecord, "module", "CHECKOUT");
+    put(configurationRecord, "configName", "other_settings");
+    put(configurationRecord, "description", description);
+    put(configurationRecord, "code", code);
+    put(configurationRecord, "value", value);
+
+    return configurationRecord;
   }
 }

--- a/mod-configuration-server/src/test/java/org/folio/support/builders/ConfigurationRecordBuilder.java
+++ b/mod-configuration-server/src/test/java/org/folio/support/builders/ConfigurationRecordBuilder.java
@@ -1,0 +1,18 @@
+package org.folio.support.builders;
+
+import io.vertx.core.json.JsonObject;
+
+public class ConfigurationRecordBuilder {
+  public static JsonObject configurationRecord(
+    String code,
+    Object value,
+    String description) {
+
+    return new JsonObject()
+      .put("module", "CHECKOUT")
+      .put("configName", "other_settings")
+      .put("description", description)
+      .put("code", code)
+      .put("value", value);
+  }
+}

--- a/mod-configuration-server/src/test/java/org/folio/support/builders/ConfigurationRecordBuilder.java
+++ b/mod-configuration-server/src/test/java/org/folio/support/builders/ConfigurationRecordBuilder.java
@@ -6,6 +6,7 @@ import java.util.UUID;
 
 public class ConfigurationRecordBuilder extends JsonBuilder {
 
+  private final UUID id;
   private final String moduleName;
   private final String configName;
   private final String code;
@@ -15,17 +16,20 @@ public class ConfigurationRecordBuilder extends JsonBuilder {
   private final UUID userId;
 
   public ConfigurationRecordBuilder() {
-    this(null, null, null, null, null, true, null);
+    this(null, null, null, null, null, null, true, null);
   }
 
   private ConfigurationRecordBuilder(
+    UUID id,
     String moduleName,
     String configName,
     String code,
     Object value,
     String description,
-    Boolean enabled, UUID userId) {
+    Boolean enabled,
+    UUID userId) {
 
+    this.id = id;
     this.moduleName = moduleName;
     this.code = code;
     this.value = value;
@@ -39,14 +43,19 @@ public class ConfigurationRecordBuilder extends JsonBuilder {
     return from(new JsonObject(example));
   }
 
-  private static ConfigurationRecordBuilder from(JsonObject example) {
+  public static ConfigurationRecordBuilder from(JsonObject example) {
     //TODO: Extract constants for properties
+
+    final UUID id = example.containsKey("id")
+      ? UUID.fromString(example.getString("id"))
+      : null;
 
     final UUID userId = example.containsKey("userId")
       ? UUID.fromString(example.getString("userId"))
       : null;
 
     return new ConfigurationRecordBuilder(
+      id,
       example.getString("module"),
       example.getString("configName"),
       example.getString("code"),
@@ -70,8 +79,21 @@ public class ConfigurationRecordBuilder extends JsonBuilder {
     return configurationRecord;
   }
 
+  public ConfigurationRecordBuilder withId(UUID id) {
+    return new ConfigurationRecordBuilder(
+      id,
+      this.moduleName,
+      this.configName,
+      this.code,
+      this.value,
+      this.description,
+      this.enabled,
+      this.userId);
+  }
+
   public ConfigurationRecordBuilder withModuleName(String moduleName) {
     return new ConfigurationRecordBuilder(
+      this.id,
       moduleName,
       this.configName,
       this.code,
@@ -83,6 +105,7 @@ public class ConfigurationRecordBuilder extends JsonBuilder {
 
   public ConfigurationRecordBuilder withConfigName(String configName) {
     return new ConfigurationRecordBuilder(
+      this.id,
       this.moduleName,
       configName,
       this.code,
@@ -94,6 +117,7 @@ public class ConfigurationRecordBuilder extends JsonBuilder {
 
   public ConfigurationRecordBuilder withCode(String code) {
     return new ConfigurationRecordBuilder(
+      this.id,
       this.moduleName,
       this.configName,
       code,
@@ -109,6 +133,7 @@ public class ConfigurationRecordBuilder extends JsonBuilder {
 
   public ConfigurationRecordBuilder withValue(Object value) {
     return new ConfigurationRecordBuilder(
+      this.id,
       this.moduleName,
       this.configName,
       this.code,
@@ -120,6 +145,7 @@ public class ConfigurationRecordBuilder extends JsonBuilder {
 
   public ConfigurationRecordBuilder withDescription(String description) {
     return new ConfigurationRecordBuilder(
+      this.id,
       this.moduleName,
       this.configName,
       this.code,
@@ -131,6 +157,7 @@ public class ConfigurationRecordBuilder extends JsonBuilder {
 
   public ConfigurationRecordBuilder disabled() {
     return new ConfigurationRecordBuilder(
+      this.id,
       this.moduleName,
       this.configName,
       this.code,
@@ -142,6 +169,7 @@ public class ConfigurationRecordBuilder extends JsonBuilder {
 
   public ConfigurationRecordBuilder forUser(UUID userId) {
     return new ConfigurationRecordBuilder(
+      this.id,
       this.moduleName,
       this.configName,
       this.code,

--- a/mod-configuration-server/src/test/java/org/folio/support/builders/ConfigurationRecordBuilder.java
+++ b/mod-configuration-server/src/test/java/org/folio/support/builders/ConfigurationRecordBuilder.java
@@ -3,18 +3,29 @@ package org.folio.support.builders;
 import io.vertx.core.json.JsonObject;
 
 public class ConfigurationRecordBuilder extends JsonBuilder {
-  public JsonObject create(
+
+  private String code;
+  private Object value;
+  private String description;
+
+  public ConfigurationRecordBuilder(
     String code,
     Object value,
     String description) {
 
+    this.code = code;
+    this.value = value;
+    this.description = description;
+  }
+
+  public JsonObject create() {
     final JsonObject configurationRecord = new JsonObject();
 
     put(configurationRecord, "module", "CHECKOUT");
     put(configurationRecord, "configName", "other_settings");
-    put(configurationRecord, "description", description);
-    put(configurationRecord, "code", code);
-    put(configurationRecord, "value", value);
+    put(configurationRecord, "description", this.description);
+    put(configurationRecord, "code", this.code);
+    put(configurationRecord, "value", this.value);
 
     return configurationRecord;
   }

--- a/mod-configuration-server/src/test/java/org/folio/support/builders/ConfigurationRecordBuilder.java
+++ b/mod-configuration-server/src/test/java/org/folio/support/builders/ConfigurationRecordBuilder.java
@@ -150,4 +150,8 @@ public class ConfigurationRecordBuilder extends JsonBuilder {
       this.enabled,
       userId);
   }
+
+  public ConfigurationRecordBuilder forNoUser() {
+    return forUser(null);
+  }
 }

--- a/mod-configuration-server/src/test/java/org/folio/support/builders/ConfigurationRecordBuilder.java
+++ b/mod-configuration-server/src/test/java/org/folio/support/builders/ConfigurationRecordBuilder.java
@@ -4,19 +4,22 @@ import io.vertx.core.json.JsonObject;
 
 public class ConfigurationRecordBuilder extends JsonBuilder {
 
+  private String moduleName;
   private String code;
   private Object value;
   private String description;
 
   public ConfigurationRecordBuilder() {
-    this(null, null, null);
+    this(null, null, null, null);
   }
 
   private ConfigurationRecordBuilder(
+    String moduleName,
     String code,
     Object value,
     String description) {
 
+    this.moduleName = moduleName;
     this.code = code;
     this.value = value;
     this.description = description;
@@ -25,7 +28,7 @@ public class ConfigurationRecordBuilder extends JsonBuilder {
   public JsonObject create() {
     final JsonObject configurationRecord = new JsonObject();
 
-    put(configurationRecord, "module", "CHECKOUT");
+    put(configurationRecord, "module", this.moduleName);
     put(configurationRecord, "configName", "other_settings");
     put(configurationRecord, "description", this.description);
     put(configurationRecord, "code", this.code);
@@ -34,8 +37,17 @@ public class ConfigurationRecordBuilder extends JsonBuilder {
     return configurationRecord;
   }
 
+  public ConfigurationRecordBuilder withModuleName(String moduleName) {
+    return new ConfigurationRecordBuilder(
+      moduleName,
+      this.code,
+      this.value,
+      this.description);
+  }
+
   public ConfigurationRecordBuilder withCode(String code) {
     return new ConfigurationRecordBuilder(
+      this.moduleName,
       code,
       this.value,
       this.description);
@@ -43,6 +55,7 @@ public class ConfigurationRecordBuilder extends JsonBuilder {
 
   public ConfigurationRecordBuilder withValue(Object value) {
     return new ConfigurationRecordBuilder(
+      this.moduleName,
       this.code,
       value,
       this.description);
@@ -50,6 +63,7 @@ public class ConfigurationRecordBuilder extends JsonBuilder {
 
   public ConfigurationRecordBuilder withDescription(String description) {
     return new ConfigurationRecordBuilder(
+      this.moduleName,
       this.code,
       this.value,
       description);

--- a/mod-configuration-server/src/test/java/org/folio/support/builders/ConfigurationRecordBuilder.java
+++ b/mod-configuration-server/src/test/java/org/folio/support/builders/ConfigurationRecordBuilder.java
@@ -3,7 +3,7 @@ package org.folio.support.builders;
 import io.vertx.core.json.JsonObject;
 
 public class ConfigurationRecordBuilder {
-  public JsonObject configurationRecord(
+  public JsonObject create(
     String code,
     Object value,
     String description) {

--- a/mod-configuration-server/src/test/java/org/folio/support/builders/ConfigurationRecordBuilder.java
+++ b/mod-configuration-server/src/test/java/org/folio/support/builders/ConfigurationRecordBuilder.java
@@ -9,9 +9,10 @@ public class ConfigurationRecordBuilder extends JsonBuilder {
   private final String code;
   private final Object value;
   private final String description;
+  private final Boolean enabled;
 
   public ConfigurationRecordBuilder() {
-    this(null, "other_settings", null, null, null);
+    this(null, "other_settings", null, null, null, true);
   }
 
   private ConfigurationRecordBuilder(
@@ -19,13 +20,30 @@ public class ConfigurationRecordBuilder extends JsonBuilder {
     String configName,
     String code,
     Object value,
-    String description) {
+    String description,
+    Boolean enabled) {
 
     this.moduleName = moduleName;
     this.code = code;
     this.value = value;
     this.description = description;
     this.configName = configName;
+    this.enabled = enabled;
+  }
+
+  public static ConfigurationRecordBuilder from(String example) {
+    return from(new JsonObject(example));
+  }
+
+  public static ConfigurationRecordBuilder from(JsonObject example) {
+    //TODO: Extract constants for properties
+    return new ConfigurationRecordBuilder(
+      example.getString("module"),
+      example.getString("configName"),
+      example.getString("code"),
+      example.getValue("value"),
+      example.getString("description"),
+      example.getBoolean("enabled"));
   }
 
   public JsonObject create() {
@@ -36,6 +54,7 @@ public class ConfigurationRecordBuilder extends JsonBuilder {
     put(configurationRecord, "description", this.description);
     put(configurationRecord, "code", this.code);
     put(configurationRecord, "value", this.value);
+    put(configurationRecord, "enabled", this.enabled);
 
     return configurationRecord;
   }
@@ -46,8 +65,8 @@ public class ConfigurationRecordBuilder extends JsonBuilder {
       this.configName,
       this.code,
       this.value,
-      this.description
-    );
+      this.description,
+      this.enabled);
   }
 
   public ConfigurationRecordBuilder withConfigName(String configName) {
@@ -56,8 +75,8 @@ public class ConfigurationRecordBuilder extends JsonBuilder {
       configName,
       this.code,
       this.value,
-      this.description
-    );
+      this.description,
+      this.enabled);
   }
 
   public ConfigurationRecordBuilder withCode(String code) {
@@ -66,8 +85,8 @@ public class ConfigurationRecordBuilder extends JsonBuilder {
       this.configName,
       code,
       this.value,
-      this.description
-    );
+      this.description,
+      this.enabled);
   }
 
   public ConfigurationRecordBuilder withValue(Object value) {
@@ -76,8 +95,8 @@ public class ConfigurationRecordBuilder extends JsonBuilder {
       this.configName,
       this.code,
       value,
-      this.description
-    );
+      this.description,
+      this.enabled);
   }
 
   public ConfigurationRecordBuilder withDescription(String description) {
@@ -86,7 +105,17 @@ public class ConfigurationRecordBuilder extends JsonBuilder {
       this.configName,
       this.code,
       this.value,
-      description
-    );
+      description,
+      this.enabled);
+  }
+
+  public ConfigurationRecordBuilder disabled() {
+    return new ConfigurationRecordBuilder(
+      this.moduleName,
+      this.configName,
+      this.code,
+      this.value,
+      this.description,
+      false);
   }
 }

--- a/mod-configuration-server/src/test/java/org/folio/support/builders/ConfigurationRecordBuilder.java
+++ b/mod-configuration-server/src/test/java/org/folio/support/builders/ConfigurationRecordBuilder.java
@@ -182,4 +182,16 @@ public class ConfigurationRecordBuilder extends JsonBuilder {
   public ConfigurationRecordBuilder forNoUser() {
     return forUser(null);
   }
+
+  public ConfigurationRecordBuilder withNoEnabled() {
+    return new ConfigurationRecordBuilder(
+      this.id,
+      this.moduleName,
+      this.configName,
+      this.code,
+      this.value,
+      this.description,
+      null,
+      this.userId);
+  }
 }

--- a/mod-configuration-server/src/test/java/org/folio/support/builders/ConfigurationRecordBuilder.java
+++ b/mod-configuration-server/src/test/java/org/folio/support/builders/ConfigurationRecordBuilder.java
@@ -2,6 +2,8 @@ package org.folio.support.builders;
 
 import io.vertx.core.json.JsonObject;
 
+import java.util.UUID;
+
 public class ConfigurationRecordBuilder extends JsonBuilder {
 
   private final String moduleName;
@@ -10,9 +12,10 @@ public class ConfigurationRecordBuilder extends JsonBuilder {
   private final Object value;
   private final String description;
   private final Boolean enabled;
+  private final UUID userId;
 
   public ConfigurationRecordBuilder() {
-    this(null, "other_settings", null, null, null, true);
+    this(null, null, null, null, null, true, null);
   }
 
   private ConfigurationRecordBuilder(
@@ -21,7 +24,7 @@ public class ConfigurationRecordBuilder extends JsonBuilder {
     String code,
     Object value,
     String description,
-    Boolean enabled) {
+    Boolean enabled, UUID userId) {
 
     this.moduleName = moduleName;
     this.code = code;
@@ -29,21 +32,28 @@ public class ConfigurationRecordBuilder extends JsonBuilder {
     this.description = description;
     this.configName = configName;
     this.enabled = enabled;
+    this.userId = userId;
   }
 
   public static ConfigurationRecordBuilder from(String example) {
     return from(new JsonObject(example));
   }
 
-  public static ConfigurationRecordBuilder from(JsonObject example) {
+  private static ConfigurationRecordBuilder from(JsonObject example) {
     //TODO: Extract constants for properties
+
+    final UUID userId = example.containsKey("userId")
+      ? UUID.fromString(example.getString("userId"))
+      : null;
+
     return new ConfigurationRecordBuilder(
       example.getString("module"),
       example.getString("configName"),
       example.getString("code"),
       example.getValue("value"),
       example.getString("description"),
-      example.getBoolean("enabled"));
+      example.getBoolean("enabled"),
+      userId);
   }
 
   public JsonObject create() {
@@ -55,6 +65,7 @@ public class ConfigurationRecordBuilder extends JsonBuilder {
     put(configurationRecord, "code", this.code);
     put(configurationRecord, "value", this.value);
     put(configurationRecord, "enabled", this.enabled);
+    put(configurationRecord, "userId", this.userId);
 
     return configurationRecord;
   }
@@ -66,7 +77,8 @@ public class ConfigurationRecordBuilder extends JsonBuilder {
       this.code,
       this.value,
       this.description,
-      this.enabled);
+      this.enabled,
+      this.userId);
   }
 
   public ConfigurationRecordBuilder withConfigName(String configName) {
@@ -76,7 +88,8 @@ public class ConfigurationRecordBuilder extends JsonBuilder {
       this.code,
       this.value,
       this.description,
-      this.enabled);
+      this.enabled,
+      this.userId);
   }
 
   public ConfigurationRecordBuilder withCode(String code) {
@@ -86,7 +99,12 @@ public class ConfigurationRecordBuilder extends JsonBuilder {
       code,
       this.value,
       this.description,
-      this.enabled);
+      this.enabled,
+      this.userId);
+  }
+
+  public ConfigurationRecordBuilder withNoCode() {
+    return withCode(null);
   }
 
   public ConfigurationRecordBuilder withValue(Object value) {
@@ -96,7 +114,8 @@ public class ConfigurationRecordBuilder extends JsonBuilder {
       this.code,
       value,
       this.description,
-      this.enabled);
+      this.enabled,
+      this.userId);
   }
 
   public ConfigurationRecordBuilder withDescription(String description) {
@@ -106,7 +125,8 @@ public class ConfigurationRecordBuilder extends JsonBuilder {
       this.code,
       this.value,
       description,
-      this.enabled);
+      this.enabled,
+      this.userId);
   }
 
   public ConfigurationRecordBuilder disabled() {
@@ -116,6 +136,18 @@ public class ConfigurationRecordBuilder extends JsonBuilder {
       this.code,
       this.value,
       this.description,
-      false);
+      false,
+      this.userId);
+  }
+
+  public ConfigurationRecordBuilder forUser(UUID userId) {
+    return new ConfigurationRecordBuilder(
+      this.moduleName,
+      this.configName,
+      this.code,
+      this.value,
+      this.description,
+      this.enabled,
+      userId);
   }
 }

--- a/mod-configuration-server/src/test/java/org/folio/support/builders/ConfigurationRecordBuilder.java
+++ b/mod-configuration-server/src/test/java/org/folio/support/builders/ConfigurationRecordBuilder.java
@@ -3,7 +3,7 @@ package org.folio.support.builders;
 import io.vertx.core.json.JsonObject;
 
 public class ConfigurationRecordBuilder {
-  public static JsonObject configurationRecord(
+  public JsonObject configurationRecord(
     String code,
     Object value,
     String description) {

--- a/mod-configuration-server/src/test/java/org/folio/support/builders/JsonBuilder.java
+++ b/mod-configuration-server/src/test/java/org/folio/support/builders/JsonBuilder.java
@@ -1,0 +1,81 @@
+package org.folio.support.builders;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import org.joda.time.DateTime;
+import org.joda.time.LocalDate;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.ISODateTimeFormat;
+
+import java.util.UUID;
+
+public abstract class JsonBuilder {
+  void put(JsonObject representation, String property, String value) {
+    if(value != null) {
+      representation.put(property, value);
+    }
+  }
+
+  void put(JsonObject representation, String property, Object value) {
+    if(value != null) {
+      representation.put(property, value);
+    }
+  }
+
+  protected void put(JsonObject representation, String property, Integer value) {
+    if(value != null) {
+      representation.put(property, value);
+    }
+  }
+
+  protected void put(JsonObject representation, String property, UUID value) {
+    if(value != null) {
+      representation.put(property, value.toString());
+    }
+  }
+
+  protected void put(JsonObject representation, String property, Boolean value) {
+    if(value != null) {
+      representation.put(property, value);
+    }
+  }
+
+  protected void put(JsonObject representation, String property, DateTime value) {
+    if(value != null) {
+      representation.put(property, value.toString(ISODateTimeFormat.dateTime()));
+    }
+  }
+
+  protected void put(JsonObject representation, String propertyName, LocalDate value) {
+    if(value != null) {
+      representation.put(propertyName, formatDateOnly(value));
+    }
+  }
+
+  protected void put(JsonObject representation, String property, JsonObject value) {
+    if(value != null) {
+      representation.put(property, value);
+    }
+  }
+
+  protected void put(
+    JsonObject representation,
+    String property,
+    Object check,
+    JsonObject value) {
+
+    if(check != null) {
+      representation.put(property, value);
+    }
+  }
+
+  protected void put(JsonObject representation, String property, JsonArray value) {
+    if(value != null) {
+      representation.put(property, value);
+    }
+  }
+
+  private String formatDateOnly(LocalDate date) {
+    return date.toString(DateTimeFormat.forPattern("yyyy-MM-dd"));
+  }
+}

--- a/mod-configuration-server/src/test/resources/urls.csv
+++ b/mod-configuration-server/src/test/resources/urls.csv
@@ -1,19 +1,19 @@
-GET , http://localhost:<port>/configurations/entries?facets=code&facets=module , get list of configuration tables , 200 , 15
+GET , http://localhost:<port>/configurations/entries?facets=code&facets=module , get list of configuration tables , 200 , 14
 GET , http://localhost:<port>/configurations/entries?query=module==CIRCULATION&facets=code&facets=module , get list of configuration tables , 200 , 4
 GET , http://localhost:<port>/configurations/entries?query=module==CIRCULATION3&facets=code&facets=module , get list of configuration tables , 200 , 0
-GET , http://localhost:<port>/configurations/entries?query=code=system%20sortBy%20code&facets=code&facets=module , get list of configuration tables , 200 , 11
-GET , http://localhost:<port>/configurations/entries?query=code=system%20sortBy%20code&facets=code:4&facets=module , get list of configuration tables , 200 , 11
-GET , http://localhost:<port>/configurations/entries?query=code=system%20sortBy%20code/sort.descending&facets=code:3&facets=module , get list of configuration tables , 200 , 11
-GET , http://localhost:<port>/configurations/entries?facets=code1&facets=module , get list of configuration tables , 200 , 15
+GET , http://localhost:<port>/configurations/entries?query=code=system%20sortBy%20code&facets=code&facets=module , get list of configuration tables , 200 , 10
+GET , http://localhost:<port>/configurations/entries?query=code=system%20sortBy%20code&facets=code:4&facets=module , get list of configuration tables , 200 , 10
+GET , http://localhost:<port>/configurations/entries?query=code=system%20sortBy%20code/sort.descending&facets=code:3&facets=module , get list of configuration tables , 200 , 10
+GET , http://localhost:<port>/configurations/entries?facets=code1&facets=module , get list of configuration tables , 200 , 14
 GET , http://localhost:<port>/configurations/entries/91287080-a81c-4a84-8d34-39cd9fedd8b5 , get specific table , 404
 GET , http://localhost:<port>/configurations/entries/91287080-a81c-4a84-8d3439cd9fedd8b5 , get specific table , 404
 GET , http://localhost:<port>/configurations/entries?query=module==CIRCULATION , get list of configuration tables , 200 , 4
 GET , http://localhost:<port>/configurations/entries?query=scope.institution_id=aaa%20sortBy%20enabled , get list of configuration tables , 400
-GET , http://localhost:<port>/configurations/audit , get list of audit records , 200 , 19
+GET , http://localhost:<port>/configurations/audit , get list of audit records , 200 , 18
 GET , http://localhost:<port>/admin/list_locking_queries , list blocking queries , 200 , 0
-GET , http://localhost:<port>/configurations/entries?query=default==true&facets=code&facets=module , get list of configuration tables , 200 , 7
-GET , http://localhost:<port>/configurations/entries?query=default==true , get list of configuration tables , 200 , 7
-GET , http://localhost:<port>/configurations/entries?query=default==true%20sortBy%20code/sort.descending , get list of configuration tables , 200 , 7
+GET , http://localhost:<port>/configurations/entries?query=default==true&facets=code&facets=module , get list of configuration tables , 200 , 6
+GET , http://localhost:<port>/configurations/entries?query=default==true , get list of configuration tables , 200 , 6
+GET , http://localhost:<port>/configurations/entries?query=default==true%20sortBy%20code/sort.descending , get list of configuration tables , 200 , 6
 GET , http://localhost:<port>/configurations/entries?query=module<1%20sortBy%20code/sort.descending&facets=code&facets=description , get list of configuration tables , 200 , 0
-GET , http://localhost:<port>/configurations/entries?query=module>1%20sortBy%20code/sort.descending&facets=module&facets=description , get list of configuration tables , 200 , 15
-GET , http://localhost:<port>/configurations/entries?query=cql.allRecords=1%20NOT%20userId=""%20or%20userId="joeshmoe" , get list of configuration tables , 200 , 15
+GET , http://localhost:<port>/configurations/entries?query=module>1%20sortBy%20code/sort.descending&facets=module&facets=description , get list of configuration tables , 200 , 14
+GET , http://localhost:<port>/configurations/entries?query=cql.allRecords=1%20NOT%20userId=""%20or%20userId="joeshmoe" , get list of configuration tables , 200 , 14

--- a/mod-configuration-server/src/test/resources/urls.csv
+++ b/mod-configuration-server/src/test/resources/urls.csv
@@ -8,7 +8,7 @@ GET , http://localhost:<port>/configurations/entries?facets=code1&facets=module 
 GET , http://localhost:<port>/configurations/entries/91287080-a81c-4a84-8d34-39cd9fedd8b5 , get specific table , 404
 GET , http://localhost:<port>/configurations/entries/91287080-a81c-4a84-8d3439cd9fedd8b5 , get specific table , 404
 GET , http://localhost:<port>/configurations/entries?query=module==CIRCULATION , get list of configuration tables , 200 , 4
-GET , http://localhost:<port>/configurations/entries?query=scope.institution_id=aaa%20sortBy%20enabled , get list of configuration tables , 422
+GET , http://localhost:<port>/configurations/entries?query=scope.institution_id=aaa%20sortBy%20enabled , get list of configuration tables , 400
 GET , http://localhost:<port>/configurations/audit , get list of audit records , 200 , 19
 GET , http://localhost:<port>/admin/list_locking_queries , list blocking queries , 200 , 0
 GET , http://localhost:<port>/configurations/entries?query=default==true&facets=code&facets=module , get list of configuration tables , 200 , 7

--- a/mod-configuration-server/src/test/resources/urls.csv
+++ b/mod-configuration-server/src/test/resources/urls.csv
@@ -1,19 +1,19 @@
-GET , http://localhost:<port>/configurations/entries?facets=code&facets=module , get list of configuration tables , 200 , 16
+GET , http://localhost:<port>/configurations/entries?facets=code&facets=module , get list of configuration tables , 200 , 15
 GET , http://localhost:<port>/configurations/entries?query=module==CIRCULATION&facets=code&facets=module , get list of configuration tables , 200 , 4
 GET , http://localhost:<port>/configurations/entries?query=module==CIRCULATION3&facets=code&facets=module , get list of configuration tables , 200 , 0
 GET , http://localhost:<port>/configurations/entries?query=code=system%20sortBy%20code&facets=code&facets=module , get list of configuration tables , 200 , 11
 GET , http://localhost:<port>/configurations/entries?query=code=system%20sortBy%20code&facets=code:4&facets=module , get list of configuration tables , 200 , 11
 GET , http://localhost:<port>/configurations/entries?query=code=system%20sortBy%20code/sort.descending&facets=code:3&facets=module , get list of configuration tables , 200 , 11
-GET , http://localhost:<port>/configurations/entries?facets=code1&facets=module , get list of configuration tables , 200 , 16
+GET , http://localhost:<port>/configurations/entries?facets=code1&facets=module , get list of configuration tables , 200 , 15
 GET , http://localhost:<port>/configurations/entries/91287080-a81c-4a84-8d34-39cd9fedd8b5 , get specific table , 404
 GET , http://localhost:<port>/configurations/entries/91287080-a81c-4a84-8d3439cd9fedd8b5 , get specific table , 404
 GET , http://localhost:<port>/configurations/entries?query=module==CIRCULATION , get list of configuration tables , 200 , 4
 GET , http://localhost:<port>/configurations/entries?query=scope.institution_id=aaa%20sortBy%20enabled , get list of configuration tables , 422
-GET , http://localhost:<port>/configurations/audit , get list of audit records , 200 , 21
+GET , http://localhost:<port>/configurations/audit , get list of audit records , 200 , 19
 GET , http://localhost:<port>/admin/list_locking_queries , list blocking queries , 200 , 0
-GET , http://localhost:<port>/configurations/entries?query=default==true&facets=code&facets=module , get list of configuration tables , 200 , 11
-GET , http://localhost:<port>/configurations/entries?query=default==true , get list of configuration tables , 200 , 11
-GET , http://localhost:<port>/configurations/entries?query=default==true%20sortBy%20code/sort.descending , get list of configuration tables , 200 , 11
+GET , http://localhost:<port>/configurations/entries?query=default==true&facets=code&facets=module , get list of configuration tables , 200 , 7
+GET , http://localhost:<port>/configurations/entries?query=default==true , get list of configuration tables , 200 , 7
+GET , http://localhost:<port>/configurations/entries?query=default==true%20sortBy%20code/sort.descending , get list of configuration tables , 200 , 7
 GET , http://localhost:<port>/configurations/entries?query=module<1%20sortBy%20code/sort.descending&facets=code&facets=description , get list of configuration tables , 200 , 0
-GET , http://localhost:<port>/configurations/entries?query=module>1%20sortBy%20code/sort.descending&facets=module&facets=description , get list of configuration tables , 200 , 16
-GET , http://localhost:<port>/configurations/entries?query=cql.allRecords=1%20NOT%20userId=""%20or%20userId="joeshmoe" , get list of configuration tables , 200 , 16
+GET , http://localhost:<port>/configurations/entries?query=module>1%20sortBy%20code/sort.descending&facets=module&facets=description , get list of configuration tables , 200 , 15
+GET , http://localhost:<port>/configurations/entries?query=cql.allRecords=1%20NOT%20userId=""%20or%20userId="joeshmoe" , get list of configuration tables , 200 , 15

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>domain-models-runtime</artifactId>
-      <version>19.0.0</version>
+      <version>19.3.1</version>
       <exclusions>
         <exclusion>
           <artifactId>commons-collections</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-configuration</artifactId>
-  <version>4.0.4-SNAPSHOT</version>
+  <version>5.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <modules>
     <module>mod-configuration-server</module>


### PR DESCRIPTION
*Purpose*

https://issues.folio.org/browse/MODCONF-21

To check that only a single configuration record is present for a given combination of `module`, `configName` and `code` (optional).

*Approach*

The implementation uses four unique indexes, each with different filtering criteria (for whether code is present and whether it is a tenant or user level record).

*Learning*

It was discovered that configuration records could be either for the tenant as a whole or a user (by the presence of the `userId` property) and could be enabled or disabled (`enabled` property).

Both of these presented additional complexity in both the scenarios and implementation of these checks. Both tenant and user level records are allowed for any given combination and disabled records are omitted from the constraints.

This does mean that it is possible for there to be multiple records, however it should only be possible to have a single enabled record defined for a given combination of module, config name and code, for the tenant or a specific user.