### PR TITLE
Fix POST item makes server side ID MODCONF-44

### DIFF
--- a/mod-configuration-server/src/main/java/org/folio/rest/impl/ConfigAPI.java
+++ b/mod-configuration-server/src/main/java/org/folio/rest/impl/ConfigAPI.java
@@ -122,6 +122,7 @@ public class ConfigAPI implements Configurations {
         String tenantId = TenantTool.calculateTenantId( okapiHeaders.get(RestVerticle.OKAPI_HEADER_TENANT) );
         PostgresClient.getInstance(context.owner(), tenantId).save(
           CONFIG_TABLE,
+          entity.getId(),
           entity,
           reply -> {
             try {


### PR DESCRIPTION
use proper PostgresClient.save with id passed. The postgresClient.save
without id should be deprecated!!  This makes tenant ref loading
work better. However, the damage for mod-configuration 5.2.0 persists.
mod-configation 5.2.0 entries have IDs that the tenant ref loading
can not refer to , because they were server side generated.