### PR TITLE
MODCONF-51: Fix Maven ${} variable replacement in src/main/resources

### DIFF
--- a/mod-configuration-client/pom.xml
+++ b/mod-configuration-client/pom.xml
@@ -23,14 +23,9 @@
   </dependencies>
 
   <build>
-    <resources>
-      <resource>
-        <directory>src/main/resources</directory>
-        <filtering>true</filtering>
-      </resource>
-    </resources>
 
     <plugins>
+
       <!-- Custom compilation mode -->
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>

--- a/mod-configuration-server/pom.xml
+++ b/mod-configuration-server/pom.xml
@@ -13,13 +13,9 @@
   </properties>
 
   <build>
-    <resources>
-      <resource>
-        <directory>src/main/resources</directory>
-        <filtering>true</filtering>
-      </resource>
-    </resources>
+
     <plugins>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -78,13 +78,9 @@
   </dependencies>
 
   <build>
-    <resources>
-      <resource>
-        <directory>src/main/resources</directory>
-        <filtering>true</filtering>
-      </resource>
-    </resources>
+
     <plugins>
+
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.1</version>


### PR DESCRIPTION
Remove unnecessary and dangerous Maven variable replacement ("variable filtering").
See https://issues.folio.org/browse/FOLIO-2548