### PR TITLE
MODCONF-54: Udate RMB to 30.2.4 fixing gin_trgm_ops schema

### DIFF
--- a/mod-configuration-server/pom.xml
+++ b/mod-configuration-server/pom.xml
@@ -20,20 +20,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.19.1</version>
-        <configuration>
-          <systemProperties>
-          </systemProperties>
-          <environmentVariables>
-            <DB_HOST>localhost</DB_HOST>
-            <DB_PORT>6000</DB_PORT>
-            <DB_DATABASE>postgres</DB_DATABASE>
-            <DB_USERNAME>username</DB_USERNAME>
-            <DB_PASSWORD>GanU/uZmfJOaxn6PaUjDeQ==</DB_PASSWORD>
-            <DB_CHARSET>UTF8</DB_CHARSET>
-            <DB_QUERYTIMEOUT>10000</DB_QUERYTIMEOUT>
-            <DB_MAXPOOLSIZE>26</DB_MAXPOOLSIZE>
-          </environmentVariables>
-        </configuration>
       </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>

--- a/mod-configuration-server/pom.xml
+++ b/mod-configuration-server/pom.xml
@@ -206,7 +206,15 @@
                 <filter>
                   <artifact>org.folio:domain-models-api-interfaces</artifact>
                   <excludes>
+                    <exclude>org/folio/rest/client/RmbtestsClient.class</exclude>
+                    <exclude>org/folio/rest/jaxrs/resource/Rmbtests*</exclude>
                     <exclude>org/folio/rest/jaxrs/resource/support/**</exclude>
+                  </excludes>
+                </filter>
+                <filter>
+                  <artifact>org.folio:domain-models-runtime</artifact>
+                  <excludes>
+                    <exclude>org/folio/rest/client/RmbtestsClient.class</exclude>
                   </excludes>
                 </filter>
                 <filter>

--- a/mod-configuration-server/src/main/resources/templates/db_scripts/migration/config_data.sql
+++ b/mod-configuration-server/src/main/resources/templates/db_scripts/migration/config_data.sql
@@ -1,25 +1,29 @@
-CREATE EXTENSION "uuid-ossp";
-
 INSERT INTO ${myuniversity}_${mymodule}.config_data
-SELECT uuid_generate_v4(),
-  jsonb - 'id' || jsonb_build_object('value', jsonb_build_object('name', json_array_elements(cast(jsonb->>'value' as json)->'selectedItems'))::text)
-  || jsonb_build_object('configName', 'orders.prefix')
-  || jsonb_build_object('code',  EXTRACT(EPOCH FROM now())::text || GENERATE_SERIES(1, json_array_length(cast(jsonb->>'value' as json)->'selectedItems')))
-FROM ${myuniversity}_${mymodule}.config_data
-WHERE jsonb->>'module' = 'ORDERS' AND jsonb->>'configName' = 'prefixes';
+SELECT md5(jsonb::text)::uuid, jsonb
+FROM (
+  SELECT jsonb - 'id'
+    || jsonb_build_object('value', jsonb_build_object('name', json_array_elements(cast(jsonb->>'value' as json)->'selectedItems'))::text)
+    || jsonb_build_object('configName', 'orders.prefix')
+    || jsonb_build_object('code',  EXTRACT(EPOCH FROM now())::text || GENERATE_SERIES(1, json_array_length(cast(jsonb->>'value' as json)->'selectedItems')))
+    AS jsonb
+  FROM ${myuniversity}_${mymodule}.config_data
+  WHERE jsonb->>'module' = 'ORDERS' AND jsonb->>'configName' = 'prefixes'
+) x;
 
 DELETE FROM ${myuniversity}_${mymodule}.config_data
 WHERE jsonb->>'module' = 'ORDERS' AND jsonb->>'configName' = 'prefixes';
 
 INSERT INTO ${myuniversity}_${mymodule}.config_data
-SELECT uuid_generate_v4(),
-  jsonb - 'id' || jsonb_build_object('value', jsonb_build_object('name', json_array_elements(cast(jsonb->>'value' as json)->'selectedItems'))::text)
-  || jsonb_build_object('configName', 'orders.suffix')
-  || jsonb_build_object('code',  EXTRACT(EPOCH FROM now())::text || GENERATE_SERIES(1, json_array_length(cast(jsonb->>'value' as json)->'selectedItems')))
-FROM ${myuniversity}_${mymodule}.config_data
-WHERE jsonb->>'module' = 'ORDERS' AND jsonb->>'configName' = 'suffixes';
+SELECT md5(jsonb::text)::uuid, jsonb
+FROM (
+  SELECT jsonb - 'id'
+    || jsonb_build_object('value', jsonb_build_object('name', json_array_elements(cast(jsonb->>'value' as json)->'selectedItems'))::text)
+    || jsonb_build_object('configName', 'orders.suffix')
+    || jsonb_build_object('code',  EXTRACT(EPOCH FROM now())::text || GENERATE_SERIES(1, json_array_length(cast(jsonb->>'value' as json)->'selectedItems')))
+    AS jsonb
+  FROM ${myuniversity}_${mymodule}.config_data
+  WHERE jsonb->>'module' = 'ORDERS' AND jsonb->>'configName' = 'suffixes'
+) x;
 
 DELETE FROM ${myuniversity}_${mymodule}.config_data
 WHERE jsonb->>'module' = 'ORDERS' AND jsonb->>'configName' = 'suffixes';
-
-DROP EXTENSION "uuid-ossp";

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>domain-models-runtime</artifactId>
-      <version>30.0.2</version>
+      <version>30.2.4</version>
       <exclusions>
         <exclusion>
           <artifactId>commons-collections</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <aspectj.version>1.8.9</aspectj.version>
+    <aspectj.version>1.9.4</aspectj.version>
     <ramlfiles_path>${project.parent.basedir}/ramls</ramlfiles_path>
     <generate_routing_context>/configurations/entries</generate_routing_context>
   </properties>


### PR DESCRIPTION
Upgrade RMB from 30.0.2 to 30.2.4 fixing gin_trgm_ops schema:
https://issues.folio.org/browse/MODORDSTOR-161

Remove uuid-ossp extension that fails in pgPool environments:
https://issues.folio.org/browse/FOLIO-2447
Use md5(jsonb::text)::uuid to calculate an unique uuid.

Let RMB automatically start embedded postgres.

Remove unused PostgreSQL configuration from pom.xml.