### PR TITLE
Revert "Use RMB snapshot with OpenJDK 11 MODCONF-57"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM folioci/alpine-jre-openjdk11:latest
+FROM folioci/alpine-jre-openjdk8:latest
 
 ENV VERTICLE_FILE mod-configuration-server-fat.jar
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,6 @@ buildMvn {
   mvnDeploy = 'yes'
   runLintRamlCop = 'yes'
   doKubeDeploy = true
-  buildNode = 'jenkins-agent-java11'
 
   doDocker = {
     buildJavaDocker {

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# This is the Docker entrypoint script specified in
+# Dockerfile.   It supports invoking the container
+# with both optional JVM runtime options as well as
+# optional module arguments.
+#
+# Example:
+#
+#  'docker run -d -e JAVA_OPTS="-Xmx256M" folio-module embed_mongo=true'
+#
+
+set -e
+
+if [ -n "$JAVA_OPTS" ]; then
+   exec java "$JAVA_OPTS" -jar ${VERTICLE_HOME}/module.jar "$@"
+else
+   exec java -jar ${VERTICLE_HOME}/module.jar "$@"
+fi
+

--- a/mod-configuration-server/pom.xml
+++ b/mod-configuration-server/pom.xml
@@ -51,9 +51,9 @@
       </plugin>
 
       <plugin>
-        <groupId>com.nickwongdev</groupId>
+        <groupId>org.codehaus.mojo</groupId>
         <artifactId>aspectj-maven-plugin</artifactId>
-        <version>1.12.6</version>
+        <version>1.9</version>
         <configuration>
           <verbose>true</verbose>
           <showWeaveInfo>false</showWeaveInfo>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <aspectj.version>1.9.5</aspectj.version>
+    <aspectj.version>1.9.4</aspectj.version>
     <ramlfiles_path>${project.parent.basedir}/ramls</ramlfiles_path>
     <generate_routing_context>/configurations/entries</generate_routing_context>
   </properties>
@@ -35,7 +35,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>domain-models-runtime</artifactId>
-      <version>31.0.0</version>
+      <version>30.2.4</version>
       <exclusions>
         <exclusion>
           <artifactId>commons-collections</artifactId>
@@ -76,9 +76,10 @@
 
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.1</version>
+        <version>3.1</version>
         <configuration>
-          <release>11</release>
+          <source>1.8</source>
+          <target>1.8</target>
           <encoding>UTF-8</encoding>
         </configuration>
       </plugin>


### PR DESCRIPTION
Reverts folio-org/mod-configuration#87

schema is missing for mod configuration see: 

https://issues.folio.org/browse/RMB-699
https://issues.folio.org/browse/MODINVSTOR-558