### PR TITLE
MODCONF-63: Upgrade branch b5.4 (Goldenrod) to RMB 30.2.9 and release

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,13 @@
+## 5.4.4 2020-10-27
+
+ * [MODCONF-63](https://issues.folio.org/browse/MODCONF-63) Upgrade RMB to 30.2.9:
+  * [RMB-740](https://issues.folio.org/browse/RMB-740) Use FOLIO fork of vertx-sql-client and vertx-pg-client with
+    the following two patches
+  * [RMB-739](https://issues.folio.org/browse/RMB-739) Make RMB's DB\_CONNECTIONRELEASEDELAY work again, defaults to 60 seconds
+  * [FOLIO-2840](https://issues.folio.org/browse/FOLIO-2840) Fix duplicate names causing 'prepared statement "XYZ" already exists'
+  * [RMB-738](https://issues.folio.org/browse/RMB-738) Upgrade to Vert.x 3.9.4, most notable fix: RowStream fetch
+    can close prematurely the stream https://github.com/eclipse-vertx/vertx-sql-client/issues/778
+
 ## 5.4.3 2020-10-14
 
  * [MODCONF-61](https://issues.folio.org/browse/MODCONF-61) Upgrade branch b5.4 (Goldenrod) to RMB 30.2.8 and release

--- a/mod-configuration-client/pom.xml
+++ b/mod-configuration-client/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>mod-configuration</artifactId>
-    <version>5.4.4-SNAPSHOT</version>
+    <version>5.4.4</version>
   </parent>
 
   <properties>

--- a/mod-configuration-client/pom.xml
+++ b/mod-configuration-client/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>mod-configuration</artifactId>
-    <version>5.4.4</version>
+    <version>5.4.5-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/mod-configuration-server/pom.xml
+++ b/mod-configuration-server/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>mod-configuration</artifactId>
-    <version>5.4.4-SNAPSHOT</version>
+    <version>5.4.4</version>
   </parent>
   <artifactId>mod-configuration-server</artifactId>
 

--- a/mod-configuration-server/pom.xml
+++ b/mod-configuration-server/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>mod-configuration</artifactId>
-    <version>5.4.4</version>
+    <version>5.4.5-SNAPSHOT</version>
   </parent>
   <artifactId>mod-configuration-server</artifactId>
 

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-configuration</artifactId>
-  <version>5.4.4-SNAPSHOT</version>
+  <version>5.4.4</version>
   <packaging>pom</packaging>
   <modules>
     <module>mod-configuration-server</module>
@@ -185,7 +185,7 @@
     <url>https://github.com/folio-org/mod-configuration</url>
     <connection>scm:git:git://github.com/folio-org/mod-configuration.git</connection>
     <developerConnection>scm:git:git@github.com/folio-org/mod-configuration.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>v5.4.4</tag>
   </scm>
 
   <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>mod-configuration</artifactId>
-  <version>5.4.4</version>
+  <version>5.4.5-SNAPSHOT</version>
   <packaging>pom</packaging>
   <modules>
     <module>mod-configuration-server</module>
@@ -185,7 +185,7 @@
     <url>https://github.com/folio-org/mod-configuration</url>
     <connection>scm:git:git://github.com/folio-org/mod-configuration.git</connection>
     <developerConnection>scm:git:git@github.com/folio-org/mod-configuration.git</developerConnection>
-    <tag>v5.4.4</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>domain-models-runtime</artifactId>
-      <version>30.2.8</version>
+      <version>30.2.9</version>
       <exclusions>
         <exclusion>
           <artifactId>commons-collections</artifactId>
@@ -58,7 +58,7 @@
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-unit</artifactId>
-      <version>3.9.2</version>
+      <version>3.9.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
* [MODCONF-63](https://issues.folio.org/browse/MODCONF-63) Upgrade RMB to 30.2.9:
  * [RMB-740](https://issues.folio.org/browse/RMB-740) Use FOLIO fork of vertx-sql-client and vertx-pg-client with
    the following two patches
  * [RMB-739](https://issues.folio.org/browse/RMB-739) Make RMB's DB\_CONNECTIONRELEASEDELAY work again, defaults to 60 seconds
  * [FOLIO-2840](https://issues.folio.org/browse/FOLIO-2840) Fix duplicate names causing 'prepared statement "XYZ" already exists'
  * [RMB-738](https://issues.folio.org/browse/RMB-738) Upgrade to Vert.x 3.9.4, most notable fix: RowStream fetch
    can close prematurely the stream https://github.com/eclipse-vertx/vertx-sql-client/issues/778