### PR TITLE
MODCONF-65: Upgrade to RMB 31.1.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>domain-models-runtime</artifactId>
-      <version>31.1.3</version>
+      <version>31.1.5</version>
       <exclusions>
         <exclusion>
           <artifactId>commons-collections</artifactId>


### PR DESCRIPTION
RMB 31.1.5 provides

* RMB-750 Change lock for "tuple concurrently updated" when upgrading Q2 to Q3 (REVOKE)

RMB 31.1.4 provides

* RMB-744 fix "tuple concurrently updated" when upgrading Q2 to Q3 (REVOKE)