### PR TITLE
MODCONF-92: Update RMB to 33.1.1 and Vert.x to 4.1.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,8 +21,8 @@
     <aspectj.version>1.9.6</aspectj.version>
     <ramlfiles_path>${project.parent.basedir}/ramls</ramlfiles_path>
     <generate_routing_context>/configurations/entries</generate_routing_context>
-    <vertx.version>4.1.2</vertx.version>
-    <raml-module-builder-version>33.0.3</raml-module-builder-version>
+    <vertx.version>4.1.4</vertx.version>
+    <raml-module-builder-version>33.1.1</raml-module-builder-version>
   </properties>
 
   <repositories>
@@ -97,7 +97,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13.1</version>
+      <version>4.13.2</version>
       <optional>true</optional>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
Most notable fix:
RMB-863 Free streamGet PreparedStatement fixing Aggressive DB Memory Consumption
https://issues.folio.org/browse/RMB-863