### PR TITLE
MODCONF-103: RMB 33.2.4, Vert.x 4.2.3, log4j 2.17.1 fixing [] in log

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,8 +21,8 @@
     <aspectj.version>1.9.7</aspectj.version>
     <ramlfiles_path>${project.parent.basedir}/ramls</ramlfiles_path>
     <generate_routing_context>/configurations/entries</generate_routing_context>
-    <vertx.version>4.2.1</vertx.version>
-    <raml-module-builder-version>33.2.2</raml-module-builder-version>
+    <vertx.version>4.2.3</vertx.version>
+    <raml-module-builder-version>33.2.4</raml-module-builder-version>
   </properties>
 
   <repositories>


### PR DESCRIPTION
Update RMB from 33.2.2 to 33.2.4.

Update Vert.x from 4.2.1 to 4.2.3.

This updates log4j from 2.16.0 to 2.17.1. This re-enables the variable expansion in the logs, currently it literally logs
`[${FolioLoggingContext:requestid}] [${FolioLoggingContext:tenantid}] [${FolioLoggingContext:userid}] [${FolioLoggingContext:moduleid}]`