### PR TITLE
MODCONF-106: RMB 33.2.8, Vertx 4.2.6, jackson-databind 2.13.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,8 +21,8 @@
     <aspectj.version>1.9.7</aspectj.version>
     <ramlfiles_path>${project.parent.basedir}/ramls</ramlfiles_path>
     <generate_routing_context>/configurations/entries</generate_routing_context>
-    <vertx.version>4.2.4</vertx.version>
-    <raml-module-builder-version>33.2.5</raml-module-builder-version>
+    <vertx.version>4.2.6</vertx.version>
+    <raml-module-builder-version>33.2.8</raml-module-builder-version>
   </properties>
 
   <repositories>


### PR DESCRIPTION
Update Vert.x from 4.2.4 to 4.2.6.

Update RMB from 33.2.5 to 33.2.8. This updates jackson-databind from 2.13.1 to 2.13.2.1 fixing https://nvd.nist.gov/vuln/detail/CVE-2020-36518