### PR TITLE
MODCONF-107: RMB 33.2.9, Vert.x 4.2.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,8 +21,8 @@
     <aspectj.version>1.9.7</aspectj.version>
     <ramlfiles_path>${project.parent.basedir}/ramls</ramlfiles_path>
     <generate_routing_context>/configurations/entries</generate_routing_context>
-    <vertx.version>4.2.6</vertx.version>
-    <raml-module-builder-version>33.2.8</raml-module-builder-version>
+    <vertx.version>4.2.7</vertx.version>
+    <raml-module-builder-version>33.2.9</raml-module-builder-version>
   </properties>
 
   <repositories>


### PR DESCRIPTION
Update dependencies:
Bump RMB from 33.2.8 to 33.2.9: https://github.com/folio-org/raml-module-builder/releases/tag/v33.2.9
Bump Vert.x from 4.2.6 to 4.2.7: https://github.com/vert-x3/wiki/wiki/4.2.7-Release-Notes

This indirectly bumps jackson-databind to 2.13.2.1 and fixes https://github.com/advisories/GHSA-57j2-w4cx-62h2 = CVE-2020-36518