### PR TITLE
MODCONF-110: Don't generate ModuleName.java for mod-configuration-client

### DIFF
--- a/mod-configuration-client/pom.xml
+++ b/mod-configuration-client/pom.xml
@@ -72,6 +72,26 @@
         </executions>
       </plugin>
 
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <version>3.1.0</version>
+        <executions>
+          <execution>
+            <id>delete_modulename</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <target>
+                <delete dir="${project.build.directory}/generated-sources/modulename" />
+              </target>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
     </plugins>
   </build>
 


### PR DESCRIPTION
mod-configuration-client is a software library, therefore it should not ship with a ModuleName.java.

The module that uses mod-configuration-client as a dependency needs to create an own ModuleName.java with its own name.