### PR TITLE
MODCONF-109: Fix source for javadoc

### DIFF
--- a/mod-configuration-client/pom.xml
+++ b/mod-configuration-client/pom.xml
@@ -39,7 +39,7 @@
             </goals>
             <configuration>
               <sources>
-                <source>${project.build.directory}/generated-sources</source>
+                <source>${project.build.directory}/generated-sources/raml-jaxrs</source>
               </sources>
             </configuration>
           </execution>


### PR DESCRIPTION
Fix source directory for correct javadoc generation.