### PR TITLE
MODCONF-158: Vert.x 4.5.25 RMB 35.4.2 fixing CVE-2025-67735 Netty CRLF

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,8 +22,8 @@
     <aspectj.version>1.9.22.1</aspectj.version>
     <ramlfiles_path>${project.parent.basedir}/ramls</ramlfiles_path>
     <generate_routing_context>/configurations/entries</generate_routing_context>
-    <vertx.version>4.5.13</vertx.version>
-    <raml-module-builder-version>35.4.1</raml-module-builder-version>
+    <vertx.version>4.5.25</vertx.version>
+    <raml-module-builder-version>35.4.2</raml-module-builder-version>
     <folio-module-descriptor-validator.version>1.0.1</folio-module-descriptor-validator.version>
   </properties>
 


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODCONF-158

https://folio-org.atlassian.net/browse/FOLIO-4430

https://github.com/folio-org/raml-module-builder/releases/tag/v35.4.2