### PR TITLE
FOLIO-4553: Set "permissions: contents: read" in maven.yml

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,9 +1,14 @@
+# https://github.com/folio-org/.github/blob/master/README-maven.md
+
 name: Maven central workflow
 
 on:
   push:
   pull_request:
   workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
   maven:


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/FOLIO-4553

Purpose

Adding "permissions: contents: read" to the repository’s maven.yml file that calls the central maven github action workflow is best practice and significantly reduces supply chain attacks: https://docs.github.com/en/actions/reference/security/secure-use

Suggested maven.yml: https://github.com/folio-org/.github/blob/master/README-maven.md#usage

Approach

Add "permissions: contents: read" to maven.yml

Learning

Follow documentation: https://github.com/folio-org/.github/blob/master/README-maven.md#usage